### PR TITLE
Update gcc-8.2 patch for arm_cmse.h c99 typeof fix

### DIFF
--- a/patches/0001-Add-GCC-8.2.patch
+++ b/patches/0001-Add-GCC-8.2.patch
@@ -1,4 +1,4 @@
-From c442ac67ecc81235d0a7c73470e081dff0b67797 Mon Sep 17 00:00:00 2001
+From 54abbdf31a9a78f4f19c17dc107373d41fe9516b Mon Sep 17 00:00:00 2001
 From: Kumar Gala <kumar.gala@linaro.org>
 Date: Mon, 30 Jul 2018 17:04:28 -0500
 Subject: [PATCH] Add GCC 8.2
@@ -25,9 +25,10 @@ Signed-off-by: Kumar Gala <kumar.gala@linaro.org>
  packages/gcc/8.2.0/0017-crystax.patch              |  34 ++
  ...RC-Add-multilib-support-for-linux-targets.patch |  76 +++
  packages/gcc/8.2.0/0019-ARM-fix-cmse.patch         |  69 +++
+ .../0020-arm-Make-arm_cmse.h-C99-compatible.patch  |  40 ++
  packages/gcc/8.2.0/chksum                          |   8 +
  packages/gcc/8.2.0/version.desc                    |   0
- 22 files changed, 1520 insertions(+)
+ 23 files changed, 1560 insertions(+)
  create mode 100644 packages/gcc/8.2.0/0000-libtool-leave-framework-alone.patch
  create mode 100644 packages/gcc/8.2.0/0001-uclibc-conf.patch
  create mode 100644 packages/gcc/8.2.0/0002-gcc-plugin-Win-Dont-need-undefined-extern-var-refs-nor-fpic.patch
@@ -48,6 +49,7 @@ Signed-off-by: Kumar Gala <kumar.gala@linaro.org>
  create mode 100644 packages/gcc/8.2.0/0017-crystax.patch
  create mode 100644 packages/gcc/8.2.0/0018-ARC-Add-multilib-support-for-linux-targets.patch
  create mode 100644 packages/gcc/8.2.0/0019-ARM-fix-cmse.patch
+ create mode 100644 packages/gcc/8.2.0/0020-arm-Make-arm_cmse.h-C99-compatible.patch
  create mode 100644 packages/gcc/8.2.0/chksum
  create mode 100644 packages/gcc/8.2.0/version.desc
 
@@ -1683,6 +1685,52 @@ index 00000000..4a501a27
 +-- 
 +2.14.4
 +
+diff --git a/packages/gcc/8.2.0/0020-arm-Make-arm_cmse.h-C99-compatible.patch b/packages/gcc/8.2.0/0020-arm-Make-arm_cmse.h-C99-compatible.patch
+new file mode 100644
+index 00000000..09899107
+--- /dev/null
++++ b/packages/gcc/8.2.0/0020-arm-Make-arm_cmse.h-C99-compatible.patch
+@@ -0,0 +1,40 @@
++From 02a72c22044c079becd5307c8b5c9552ba0c7f53 Mon Sep 17 00:00:00 2001
++From: avieira <avieira@138bc75d-0d04-0410-961f-82ee72b054a4>
++Date: Tue, 5 Jun 2018 15:07:09 +0000
++Subject: [PATCH] [arm] Make arm_cmse.h C99 compatible
++
++gcc/ChangeLog
++2018-06-05  Andre Vieira  <andre.simoesdiasvieira@arm.com>
++
++	* config/arm/arm_cmse.h (cmse_nsfptr_create): Change typeof to
++	__typeof__.
++	(cmse_check_pointed_object): Likewise.
++
++git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/trunk@261204 138bc75d-0d04-0410-961f-82ee72b054a4
++---
++ gcc/config/arm/arm_cmse.h                     | 4 ++--
++ 4 files changed, 16 insertions(+), 2 deletions(-)
++ create mode 100644 gcc/testsuite/gcc.target/arm/cmse/cmse-1c99.c
++
++diff --git a/gcc/config/arm/arm_cmse.h b/gcc/config/arm/arm_cmse.h
++index f972e23659d..9b35537cd33 100644
++--- a/gcc/config/arm/arm_cmse.h
+++++ b/gcc/config/arm/arm_cmse.h
++@@ -173,7 +173,7 @@ cmse_nonsecure_caller (void)
++ #define CMSE_MPU_NONSECURE	16
++ #define CMSE_NONSECURE		18
++ 
++-#define cmse_nsfptr_create(p) ((typeof ((p))) ((__INTPTR_TYPE__) (p) & ~1))
+++#define cmse_nsfptr_create(p) ((__typeof__ ((p))) ((__INTPTR_TYPE__) (p) & ~1))
++ 
++ #define cmse_is_nsfptr(p) (!((__INTPTR_TYPE__) (p) & 1))
++ 
++@@ -187,7 +187,7 @@ __extension__ void *
++ cmse_check_address_range (void *, size_t, int);
++ 
++ #define cmse_check_pointed_object(p, f) \
++-  ((typeof ((p))) cmse_check_address_range ((p), sizeof (*(p)), (f)))
+++  ((__typeof__ ((p))) cmse_check_address_range ((p), sizeof (*(p)), (f)))
++ 
++ #endif /* __ARM_FEATURE_CMSE & 1 */
++ 
 diff --git a/packages/gcc/8.2.0/chksum b/packages/gcc/8.2.0/chksum
 new file mode 100644
 index 00000000..c6c0eca0


### PR DESCRIPTION
Pull in patch from upstream gcc that fixes use of typeof.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>