### PR TITLE
openocd: bump to zephyr-20190226 branch

### DIFF
--- a/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_0.10.0.bb
+++ b/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_0.10.0.bb
@@ -9,7 +9,7 @@ RDEPENDS_${PN} = "libusb1 hidapi-libraw"
 SRC_URI = " \
 	git://github.com/zephyrproject-rtos/openocd.git;protocol=https;nobranch=1 \
 	"
-SRCREV = "d34bc2055d3d749c3176a20541e4296a44ed1fa2"
+SRCREV = "0b1cbf1759aee0b68ac73ae8d8af7fe1c9f0c35f"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The zephyr-20190226 branch adds a few patches for fixing the Zephyr RTOS
awareness, and a set of workaround patches for reset issue on CC3220.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>