### PR TITLE
configs/all: add --enable-initfini-array to gcc configure

### DIFF
--- a/configs/arc.config
+++ b/configs/arc.config
@@ -18,7 +18,7 @@ CT_LIBC_NEWLIB_LITE_EXIT=y
 # CT_LIBC_NEWLIB_WIDE_ORIENT is not set
 CT_LIBC_NEWLIB_NANO_MALLOC=y
 CT_LIBC_NEWLIB_NANO_FORMATTED_IO=y
-CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as"
+CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array"
 CT_CC_LANG_CXX=y
 CT_DEBUG_GDB=y
 CT_ISL_V_0_18=y

--- a/configs/arm.config
+++ b/configs/arm.config
@@ -19,7 +19,7 @@ CT_LIBC_NEWLIB_LITE_EXIT=y
 # CT_LIBC_NEWLIB_WIDE_ORIENT is not set
 CT_LIBC_NEWLIB_NANO_MALLOC=y
 CT_LIBC_NEWLIB_NANO_FORMATTED_IO=y
-CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as"
+CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array"
 CT_CC_GCC_MULTILIB_LIST="rmprofile"
 CT_CC_LANG_CXX=y
 CT_DEBUG_GDB=y

--- a/configs/i586.config
+++ b/configs/i586.config
@@ -20,7 +20,7 @@ CT_LIBC_NEWLIB_LITE_EXIT=y
 # CT_LIBC_NEWLIB_WIDE_ORIENT is not set
 CT_LIBC_NEWLIB_NANO_MALLOC=y
 CT_LIBC_NEWLIB_NANO_FORMATTED_IO=y
-CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as"
+CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array"
 CT_CC_LANG_CXX=y
 CT_DEBUG_GDB=y
 CT_ISL_V_0_18=y

--- a/configs/iamcu.config
+++ b/configs/iamcu.config
@@ -20,7 +20,7 @@ CT_LIBC_NEWLIB_LITE_EXIT=y
 # CT_LIBC_NEWLIB_WIDE_ORIENT is not set
 CT_LIBC_NEWLIB_NANO_MALLOC=y
 CT_LIBC_NEWLIB_NANO_FORMATTED_IO=y
-CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as"
+CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array"
 CT_CC_LANG_CXX=y
 CT_DEBUG_GDB=y
 CT_ISL_V_0_18=y

--- a/configs/mips.config
+++ b/configs/mips.config
@@ -18,7 +18,7 @@ CT_LIBC_NEWLIB_LITE_EXIT=y
 # CT_LIBC_NEWLIB_WIDE_ORIENT is not set
 CT_LIBC_NEWLIB_NANO_MALLOC=y
 CT_LIBC_NEWLIB_NANO_FORMATTED_IO=y
-CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as"
+CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array"
 CT_CC_LANG_CXX=y
 CT_DEBUG_GDB=y
 CT_ISL_V_0_18=y

--- a/configs/nios2.config
+++ b/configs/nios2.config
@@ -18,7 +18,7 @@ CT_LIBC_NEWLIB_LITE_EXIT=y
 # CT_LIBC_NEWLIB_WIDE_ORIENT is not set
 CT_LIBC_NEWLIB_NANO_MALLOC=y
 CT_LIBC_NEWLIB_NANO_FORMATTED_IO=y
-CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as"
+CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array"
 CT_CC_LANG_CXX=y
 CT_DEBUG_GDB=y
 CT_ISL_V_0_18=y

--- a/configs/riscv32.config
+++ b/configs/riscv32.config
@@ -21,7 +21,7 @@ CT_LIBC_NEWLIB_LITE_EXIT=y
 # CT_LIBC_NEWLIB_WIDE_ORIENT is not set
 CT_LIBC_NEWLIB_NANO_MALLOC=y
 CT_LIBC_NEWLIB_NANO_FORMATTED_IO=y
-CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as"
+CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array"
 CT_CC_LANG_CXX=y
 CT_DEBUG_GDB=y
 CT_ISL_V_0_18=y

--- a/configs/xtensa.config
+++ b/configs/xtensa.config
@@ -24,7 +24,7 @@ CT_LIBC_NEWLIB_LITE_EXIT=y
 # CT_LIBC_NEWLIB_WIDE_ORIENT is not set
 CT_LIBC_NEWLIB_NANO_MALLOC=y
 CT_LIBC_NEWLIB_NANO_FORMATTED_IO=y
-CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as"
+CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array"
 CT_CC_LANG_CXX=y
 CT_DEBUG_GDB=y
 CT_ISL_V_0_18=y


### PR DESCRIPTION
The --enable-initfini-array configure flag forces GCC to use
init/fini arrays instead of just init/fini functions, as GCC
would choose to do functions depending on arch. With only
init/fini functions, apps built with coverage would not
dump any coverage data because __gcov_init() is never called.
With this flag, GCC will use init array which is required
for the correct operation of gcov_static_init().

Signed-off-by: Daniel Leung <daniel.leung@intel.com>