### PR TITLE
Fix MIPS toolchain not being included in SDK

### DIFF
--- a/scripts/make_zephyr_sdk.sh
+++ b/scripts/make_zephyr_sdk.sh
@@ -53,7 +53,7 @@ parse_toolchain_name file_gcc_arm arm
 parse_toolchain_name file_gcc_arc arc
 parse_toolchain_name file_gcc_x86 i586
 parse_toolchain_name file_gcc_iamcu iamcu
-parse_toolchain_name file_gcc_mips mips32r2
+parse_toolchain_name file_gcc_mips mips
 parse_toolchain_name file_gcc_nios2 nios2
 parse_toolchain_name file_gcc_xtensa xtensa
 parse_toolchain_name file_gcc_riscv32 riscv32


### PR DESCRIPTION
The script to create the SDK file looks for built toolchain
archive name containing "mips32r2", but the actual archive
is mips.tar.bz2. So update the script to look for the correct
name.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>