### PR TITLE
openocd: fix issue on ARC based systems

### DIFF
--- a/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_0.10.0.bb
+++ b/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_0.10.0.bb
@@ -9,7 +9,7 @@ RDEPENDS_${PN} = "libusb1 hidapi-libraw"
 SRC_URI = " \
 	git://github.com/zephyrproject-rtos/openocd.git;protocol=https;nobranch=1 \
 	"
-SRCREV = "0b1cbf1759aee0b68ac73ae8d8af7fe1c9f0c35f"
+SRCREV = "5b23e3b553a916809ac59967c06278942c37447d"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This fixes issues with ARC based systems and adds 2 patches addressing
the problem.

Fixes #65