### PR TITLE
openocd: Update rev for TI & and some ARC fixes

### DIFF
--- a/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_0.10.0.bb
+++ b/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_0.10.0.bb
@@ -9,7 +9,7 @@ RDEPENDS_${PN} = "libusb1 hidapi-libraw"
 SRC_URI = " \
 	git://github.com/zephyrproject-rtos/openocd.git;protocol=https;nobranch=1 \
 	"
-SRCREV = "0b1cbf1759aee0b68ac73ae8d8af7fe1c9f0c35f"
+SRCREV = "697677c416da65bc3458ec1aefe70992b1e9ef82"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
We pull in some of the ARC fixes from openocd (GDB fix still pending
upstream).  Also pull in a cleaner fix for the TI CC32xx reset issue.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>