### PR TITLE
openocd: Pull in newer version for XDS110 reset issue

### DIFF
--- a/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_0.10.0.bb
+++ b/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_0.10.0.bb
@@ -9,7 +9,7 @@ RDEPENDS_${PN} = "libusb1 hidapi-libraw"
 SRC_URI = " \
 	git://github.com/zephyrproject-rtos/openocd.git;protocol=https;nobranch=1 \
 	"
-SRCREV = "1df07a9a442a3839e29a295e67bb057deb08f058"
+SRCREV = "3333261df1edf48571d6415e4383d7c78753eeed"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
We need the workaround for the nSRST for TI CC13x2/CC26x2 platforms.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>