### PR TITLE
qemu: Enable aarch64 target

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
@@ -193,7 +193,7 @@ inherit autotools pkgconfig
 #--disable-blobs : BIOS needed for x86
 #--disable-fdt: Cannot use if supporting ARM
 
-QEMUS_BUILT = "arm-softmmu i386-softmmu mips-softmmu nios2-softmmu xtensa-softmmu riscv32-softmmu x86_64-softmmu"
+QEMUS_BUILT = "aarch64-softmmu arm-softmmu i386-softmmu mips-softmmu nios2-softmmu xtensa-softmmu riscv32-softmmu x86_64-softmmu"
 QEMU_FLAGS = "--disable-docs  --disable-sdl --disable-debug-info  --disable-cap-ng \
   --disable-libnfs --disable-libusb --disable-libiscsi --disable-usb-redir --disable-linux-aio\
   --disable-guest-agent --disable-libssh2 --disable-vnc-png  --disable-seccomp \


### PR DESCRIPTION
In order to support Cortex-R development, we will run a xlnx-zcu102 qemu
machine.  However, the application processors on that machine are 64 bit
A53s so the qemu executable to run it is aarch64-softmmu.

Signed-off-by: Bradley Bolen <bbolen@lexmark.com>

Note that this will allow running the "Hello World" sample application.  However, none of the other samples will run because the GIC is not hooked up to the R5 on the zcu102.  If that is not sufficient, then I'm fine dropping this PR and we can come up with some other platform for cortex-r support.