### PR TITLE
xtensa: enable remainderf and sqrtf in newlib

### DIFF
--- a/patches/newlib/git-b06f1b57/xtensa-enable-remainderf.patch
+++ b/patches/newlib/git-b06f1b57/xtensa-enable-remainderf.patch
@@ -1,0 +1,34 @@
+From 003f19030687474afc1c4633e448b520ecf88da3 Mon Sep 17 00:00:00 2001
+From: Daniel Leung <daniel.leung@intel.com>
+Date: Wed, 13 Mar 2019 16:18:08 -0700
+Subject: [PATCH 1/2] xtensa: enable remainderf
+
+Xtensa libgcc does not supply this, so need to enable in libm.
+
+Signed-off-by: Daniel Leung <daniel.leung@intel.com>
+---
+ newlib/libm/math/ef_remainder.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/newlib/libm/math/ef_remainder.c b/newlib/libm/math/ef_remainder.c
+index 5371009f..4c805f90 100644
+--- a/newlib/libm/math/ef_remainder.c
++++ b/newlib/libm/math/ef_remainder.c
+@@ -17,8 +17,6 @@
+ 
+ /* __ieee754_remainderf is provided by libgcc */
+ 
+-#if 0
+-
+ #ifdef __STDC__
+ static const float zero = 0.0;
+ #else
+@@ -70,5 +68,3 @@ static float zero = 0.0;
+ 	SET_FLOAT_WORD(x,hx^sx);
+ 	return x;
+ }
+-
+-#endif /* 0 */
+-- 
+2.19.2
+

--- a/patches/newlib/git-b06f1b57/xtensa-enable-sqrtf.patch
+++ b/patches/newlib/git-b06f1b57/xtensa-enable-sqrtf.patch
@@ -1,0 +1,33 @@
+From f15d0857cef3e0b0378a7d1214b9f9221661abd9 Mon Sep 17 00:00:00 2001
+From: Daniel Leung <daniel.leung@intel.com>
+Date: Wed, 13 Mar 2019 16:20:46 -0700
+Subject: [PATCH 2/2] xtensa: enable sqrtf
+
+Xtensa libgcc does not supply this, so need to enable in libm.
+
+Signed-off-by: Daniel Leung <daniel.leung@intel.com>
+---
+ newlib/libm/math/ef_sqrt.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/newlib/libm/math/ef_sqrt.c b/newlib/libm/math/ef_sqrt.c
+index a6cd13f0..18cc8bdc 100644
+--- a/newlib/libm/math/ef_sqrt.c
++++ b/newlib/libm/math/ef_sqrt.c
+@@ -26,7 +26,6 @@ static	const float	one	= 1.0, tiny=1.0e-30;
+ static	float	one	= 1.0, tiny=1.0e-30;
+ #endif
+ 
+-#if !XCHAL_HAVE_FP_SQRT
+ 
+ #ifdef __STDC__
+ 	float __ieee754_sqrtf(float x)
+@@ -95,5 +94,4 @@ static	float	one	= 1.0, tiny=1.0e-30;
+ 	return z;
+ }
+ 
+-#endif /* !XCHAL_HAVE_FP_SQRT */
+ 
+-- 
+2.19.2
+


### PR DESCRIPTION
Upstream GCC does not provide these functions in libgcc,
so need to enable them in newlib/libm.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>