### PR TITLE
make_zephyr_sdk: Remove xtensa arch

### DIFF
--- a/scripts/make_zephyr_sdk.sh
+++ b/scripts/make_zephyr_sdk.sh
@@ -111,13 +111,6 @@ if [ -n "$file_gcc_nios2" ]; then
   echo "echo \"\"" >>$setup
 fi
 
-if [ -n "$file_gcc_xtensa" ]; then
-  echo "tar -C \$target_sdk_dir -jxf ./$file_gcc_xtensa > /dev/null &" >> $setup
-  echo "spinner \$!  \"Installing xtensa tools...\"" >> $setup
-  echo "[ \$? -ne 0 ] && echo \"Error(s) encountered during installation.\" && exit 1" >>$setup
-  echo "echo \"\"" >>$setup
-fi
-
 if [ -n "$file_gcc_riscv64" ]; then
   echo "tar -C \$target_sdk_dir -jxf ./$file_gcc_riscv64 > /dev/null &" >> $setup
   echo "spinner \$!  \"Installing riscv64 tools...\"" >> $setup


### PR DESCRIPTION
xtensa as a generic target doesn't exist, its now xtensa_controller,
xtensa_intel_apl_adsp, xtensa_intel_s1000.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>