### PR TITLE
make_zephyr_sdk.sh: remove parse_toolchain_name call for xtensa

### DIFF
--- a/scripts/make_zephyr_sdk.sh
+++ b/scripts/make_zephyr_sdk.sh
@@ -166,9 +166,7 @@ create_sdk()
 parse_toolchain_name file_gcc_arm arm
 parse_toolchain_name file_gcc_arc arc
 parse_toolchain_name file_gcc_x86 i586
-#parse_toolchain_name file_gcc_mips mips
 parse_toolchain_name file_gcc_nios2 nios2
-parse_toolchain_name file_gcc_xtensa xtensa
 parse_toolchain_name file_gcc_riscv64 riscv64
 parse_toolchain_name file_gcc_x86_64 x86_64-zephyr-elf
 parse_toolchain_name file_gcc_xtensa_sample_controller xtensa_sample_controller


### PR DESCRIPTION
Since we now have xtensa target specific toolchains the generic xtensa
target doesn't exist.  So remove it.  (causes a build error).

Also remove mips (its been commented out).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>