### PR TITLE
x86_64: update GCC 9.2.0 patch file and default march

### DIFF
--- a/configs/x86_64-zephyr-elf.config
+++ b/configs/x86_64-zephyr-elf.config
@@ -18,8 +18,8 @@ CT_LIBC_NEWLIB_LITE_EXIT=y
 # CT_LIBC_NEWLIB_WIDE_ORIENT is not set
 CT_LIBC_NEWLIB_NANO_MALLOC=y
 CT_LIBC_NEWLIB_NANO_FORMATTED_IO=y
-CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array"
-CT_CC_GCC_MULTILIB_LIST="m64,m32,mx32"
+CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array --with-cpu-32=i586 --with-arch-32=i586 --with-cpu-64=generic --with-arch-64=x86-64"
+# CT_CC_GCC_LIBMPX is not set
 CT_CC_LANG_CXX=y
 CT_DEBUG_GDB=y
 CT_ISL_V_0_18=y

--- a/patches/gcc/9.2.0/0012-Add-support-to-build-for-x86_64-zephyr-elf.patch
+++ b/patches/gcc/9.2.0/0012-Add-support-to-build-for-x86_64-zephyr-elf.patch
@@ -1,6 +1,6 @@
-From c751c96f0e7f8e48690443796f71f05bb564763d Mon Sep 17 00:00:00 2001
-From: Kumar Gala <kumar.gala@linaro.org>
-Date: Wed, 7 Aug 2019 05:20:44 -0500
+From 08fb7674fc7ec232c81fb460da77ef7c342985a7 Mon Sep 17 00:00:00 2001
+From: Daniel Leung <danielcp@gmail.com>
+Date: Fri, 11 Oct 2019 16:36:17 -0700
 Subject: [PATCH 12/14] Add support to build for x86_64-zephyr-elf
 
 This adds the necessary bits to build for x86_64-zephyr-elf with
@@ -10,32 +10,53 @@ footsteps.
 Signed-off-by: Kumar Gala <kumar.gala@linaro.org>
 Signed-off-by: Daniel Leung <daniel.leung@intel.com>
 ---
- configure                        |  2 +-
+ config/dfp.m4                    |  1 +
  gcc/acinclude.m4                 | 12 ++++++++++
- gcc/config.gcc                   | 27 +++++++++++++++++++++++
- gcc/config/i386/t-zephyr64       | 38 ++++++++++++++++++++++++++++++++
- gcc/configure                    |  9 ++++++++
- libgcc/config.host               |  7 +++++-
+ gcc/config.gcc                   |  5 ++++
+ gcc/config/i386/t-zephyr64       | 35 ++++++++++++++++++++++++++++
+ gcc/config/i386/zephyr64.h       | 39 ++++++++++++++++++++++++++++++++
+ gcc/configure                    | 16 ++++++++++---
+ libatomic/configure              |  6 ++---
+ libbacktrace/configure           |  6 ++---
+ libcc1/configure                 |  6 ++---
+ libdecnumber/configure           |  1 +
+ libffi/configure                 |  6 ++---
+ libgcc/config.host               |  5 ++++
  libgcc/config/i386/64/t-zephyr64 |  1 +
- 7 files changed, 94 insertions(+), 2 deletions(-)
+ libgcc/configure                 |  1 +
+ libgfortran/configure            |  6 ++---
+ libgomp/configure                |  6 ++---
+ libhsail-rt/configure            |  6 ++---
+ libitm/configure                 |  6 ++---
+ libphobos/configure              |  6 ++---
+ libquadmath/configure            |  6 ++---
+ libsanitizer/configure           |  6 ++---
+ libssp/configure                 |  6 ++---
+ libstdc++-v3/configure           |  6 ++---
+ libstdc++-v3/configure.host      |  9 ++++++++
+ libtool.m4                       |  6 ++---
+ libvtv/configure                 |  6 ++---
+ lto-plugin/configure             |  6 ++---
+ zlib/configure                   |  6 ++---
+ 28 files changed, 173 insertions(+), 54 deletions(-)
  create mode 100644 gcc/config/i386/t-zephyr64
+ create mode 100644 gcc/config/i386/zephyr64.h
  create mode 100644 libgcc/config/i386/64/t-zephyr64
 
-diff --git a/configure b/configure
-index abd93a990a9..4d30ac4e320 100755
---- a/configure
-+++ b/configure
-@@ -7561,7 +7561,7 @@ fi
- # Special user-friendly check for native x86_64-linux build, if
- # multilib is not explicitly enabled.
- case "$target:$have_compiler:$host:$target:$enable_multilib" in
--  x86_64-*linux*:yes:$build:$build:)
-+  x86_64-*linux*:yes:$build:$build: | x86_64-zephyr-elf:yes:$build:$build:)
-     # Make sure we have a development environment that handles 32-bit
-     dev64=no
-     echo "int main () { return 0; }" > conftest.c
+diff --git a/config/dfp.m4 b/config/dfp.m4
+index a137ddebf..f726d6992 100644
+--- a/config/dfp.m4
++++ b/config/dfp.m4
+@@ -21,6 +21,7 @@ Valid choices are 'yes', 'bid', 'dpd', and 'no'.]) ;;
+ [
+   case $1 in
+     powerpc*-*-linux* | i?86*-*-linux* | x86_64*-*-linux* | s390*-*-linux* | \
++    x86_64-zephyr-* | \
+     i?86*-*-elfiamcu | i?86*-*-gnu* | x86_64*-*-gnu* | \
+     i?86*-*-mingw* | x86_64*-*-mingw* | \
+     i?86*-*-cygwin* | x86_64*-*-cygwin*)
 diff --git a/gcc/acinclude.m4 b/gcc/acinclude.m4
-index e3d50dca708..09d9380227e 100644
+index e3d50dca7..09d938022 100644
 --- a/gcc/acinclude.m4
 +++ b/gcc/acinclude.m4
 @@ -507,6 +507,18 @@ AC_DEFUN([gcc_GAS_FLAGS],
@@ -58,49 +79,27 @@ index e3d50dca708..09d9380227e 100644
      dnl Always pass -arch ppc to assembler.
      gcc_cv_as_flags="-arch ppc"
 diff --git a/gcc/config.gcc b/gcc/config.gcc
-index ddd3b8f4d9d..34efe191505 100644
+index ddd3b8f4d..21a46922c 100644
 --- a/gcc/config.gcc
 +++ b/gcc/config.gcc
-@@ -1635,6 +1635,33 @@ i[34567]86-*-elfiamcu)
+@@ -1635,6 +1635,11 @@ i[34567]86-*-elfiamcu)
  i[34567]86-*-elf*)
  	tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h newlib-stdint.h i386/i386elf.h"
  	;;
 +x86_64-zephyr-elf*)
 +	tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h newlib-stdint.h i386/i386elf.h i386/x86-64.h"
++	tm_file="${tm_file} i386/zephyr64.h"
 +	tmake_file="${tmake_file} i386/t-zephyr64"
-+	x86_multilibs="${with_multilib_list}"
-+	if test "$x86_multilibs" = "default"; then
-+		case ${with_abi} in
-+		x32 | mx32)
-+			x86_multilibs="mx32"
-+			;;
-+		*)
-+			x86_multilibs="m64,m32"
-+			;;
-+		esac
-+	fi
-+	x86_multilibs=`echo $x86_multilibs | sed -e 's/,/ /g'`
-+	for x86_multilib in ${x86_multilibs}; do
-+		case ${x86_multilib} in
-+		m32 | m64 | mx32)
-+			TM_MULTILIB_CONFIG="${TM_MULTILIB_CONFIG},${x86_multilib}"
-+			;;
-+		*)
-+			echo "--with-multilib-list=${x86_with_multilib} not supported."
-+			exit 1
-+		esac
-+	done
-+	TM_MULTILIB_CONFIG=`echo $TM_MULTILIB_CONFIG | sed 's/^,//'`
 +	;;
  x86_64-*-elf*)
  	tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h newlib-stdint.h i386/i386elf.h i386/x86-64.h"
  	;;
 diff --git a/gcc/config/i386/t-zephyr64 b/gcc/config/i386/t-zephyr64
 new file mode 100644
-index 00000000000..a47de29029e
+index 000000000..6101785fd
 --- /dev/null
 +++ b/gcc/config/i386/t-zephyr64
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,35 @@
 +# Copyright (C) 2002-2018 Free Software Foundation, Inc.
 +#
 +# This file is part of GCC.
@@ -133,17 +132,94 @@ index 00000000000..a47de29029e
 +# 	/lib64 has x86-64 libraries.
 +# 	/libx32 has x32 libraries.
 +#
-+comma=,
-+MULTILIB_OPTIONS    = $(subst $(comma),/,$(TM_MULTILIB_CONFIG))
-+MULTILIB_DIRNAMES   = $(patsubst m%, %, $(subst /, ,$(MULTILIB_OPTIONS)))
-+MULTILIB_OSDIRNAMES = m64=../lib64$(call if_multiarch,:x86_64-zephyr-elf)
-+MULTILIB_OSDIRNAMES+= m32=$(if $(wildcard $(shell echo $(SYSTEM_HEADER_DIR))/../../usr/lib32),../lib32,../lib)$(call if_multiarch,:i386-zephyr-elf)
-+MULTILIB_OSDIRNAMES+= mx32=../libx32$(call if_multiarch,:x86_64-zephyr-elfx32)
++MULTILIB_OPTIONS    = m64/m32/mx32
++MULTILIB_DIRNAMES   = 64 32 x32
++MULTILIB_OSDIRNAMES = m64=!64 m32=!32 mx32=!x32
+diff --git a/gcc/config/i386/zephyr64.h b/gcc/config/i386/zephyr64.h
+new file mode 100644
+index 000000000..dba11cdf2
+--- /dev/null
++++ b/gcc/config/i386/zephyr64.h
+@@ -0,0 +1,39 @@
++/* Definitions for x86-64 for Zephyr 64-bit toolchain.
++   Copyright (C) 2001-2019 Free Software Foundation, Inc.
++   Contributed by Jan Hubicka <jh@suse.cz>, based on linux.h.
++   Based on gnu-user64.h.
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation; either version 3, or (at your option)
++any later version.
++
++GCC is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++GNU General Public License for more details.
++
++Under Section 7 of GPL version 3, you are granted additional
++permissions described in the GCC Runtime Library Exception, version
++3.1, as published by the Free Software Foundation.
++
++You should have received a copy of the GNU General Public License and
++a copy of the GCC Runtime Library Exception along with this program;
++see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++<http://www.gnu.org/licenses/>.  */
++
++#undef ENDFILE_SPEC
++#define ENDFILE_SPEC "crtend.o%s"
++
++#undef STARTFILE_SPEC
++#define STARTFILE_SPEC "crtbegin.o%s"
++
++#undef	LINK_SPEC
++#define LINK_SPEC \
++	"%{m32:-m elf_i386} \
++	 %{m64:-m elf_x86_64} \
++	 %{mx32:-m elf32_x86_64}"
++
++#define MULTILIB_DEFAULTS { "m64" }
 diff --git a/gcc/configure b/gcc/configure
-index 481071b4265..802fa4c67f8 100755
+index 481071b42..66a7b5564 100755
 --- a/gcc/configure
 +++ b/gcc/configure
-@@ -22671,6 +22671,15 @@ else
+@@ -7555,6 +7555,7 @@ else
+ 
+   case $target in
+     powerpc*-*-linux* | i?86*-*-linux* | x86_64*-*-linux* | s390*-*-linux* | \
++    x86_64*-zephyr-* | \
+     i?86*-*-elfiamcu | i?86*-*-gnu* | x86_64*-*-gnu* | \
+     i?86*-*-mingw* | x86_64*-*-mingw* | \
+     i?86*-*-cygwin* | x86_64*-*-cygwin*)
+@@ -14401,7 +14402,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -14416,7 +14417,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -14445,7 +14446,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
+@@ -22671,6 +22672,15 @@ else
    x86_64-*-linux*)
          gcc_cv_as_flags=--64
      ;;
@@ -159,8 +235,144 @@ index 481071b4265..802fa4c67f8 100755
    powerpc*-*-darwin*)
          gcc_cv_as_flags="-arch ppc"
      ;;
+diff --git a/libatomic/configure b/libatomic/configure
+index e7076a0ff..01f17ba33 100755
+--- a/libatomic/configure
++++ b/libatomic/configure
+@@ -6842,7 +6842,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -6857,7 +6857,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -6886,7 +6886,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
+diff --git a/libbacktrace/configure b/libbacktrace/configure
+index 51d7cb458..c248654f6 100755
+--- a/libbacktrace/configure
++++ b/libbacktrace/configure
+@@ -7246,7 +7246,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -7261,7 +7261,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -7290,7 +7290,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
+diff --git a/libcc1/configure b/libcc1/configure
+index 53f40d311..c081a095e 100755
+--- a/libcc1/configure
++++ b/libcc1/configure
+@@ -6530,7 +6530,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -6545,7 +6545,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -6574,7 +6574,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
+diff --git a/libdecnumber/configure b/libdecnumber/configure
+index 14c103a07..7dc4ceba6 100755
+--- a/libdecnumber/configure
++++ b/libdecnumber/configure
+@@ -4762,6 +4762,7 @@ else
+ 
+   case $target in
+     powerpc*-*-linux* | i?86*-*-linux* | x86_64*-*-linux* | s390*-*-linux* | \
++    x86_64-zephyr-* | \
+     i?86*-*-elfiamcu | i?86*-*-gnu* | x86_64*-*-gnu* | \
+     i?86*-*-mingw* | x86_64*-*-mingw* | \
+     i?86*-*-cygwin* | x86_64*-*-cygwin*)
+diff --git a/libffi/configure b/libffi/configure
+index 2324890a5..5025d959b 100755
+--- a/libffi/configure
++++ b/libffi/configure
+@@ -7038,7 +7038,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -7053,7 +7053,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -7082,7 +7082,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
 diff --git a/libgcc/config.host b/libgcc/config.host
-index 91abc84da03..623291995c7 100644
+index 91abc84da..d94f092a2 100644
 --- a/libgcc/config.host
 +++ b/libgcc/config.host
 @@ -632,6 +632,11 @@ i[34567]86-*-elfiamcu)
@@ -175,22 +387,448 @@ index 91abc84da03..623291995c7 100644
  x86_64-*-elf* | x86_64-*-rtems*)
  	tmake_file="$tmake_file i386/t-crtstuff t-crtstuff-pic t-libgcc-pic"
  	case ${host} in
-@@ -1458,7 +1463,7 @@ i[34567]86-*-* | x86_64-*-*)
- esac
- 
- case ${host} in
--i[34567]86-*-linux* | x86_64-*-linux*)
-+i[34567]86-*-linux* | x86_64-*-linux* | x86_64-zephyr-elf)
- 	# Provide backward binary compatibility for 64bit Linux/x86.
- 	if test "${host_address}" = 64; then
- 		tmake_file="${tmake_file} i386/${host_address}/t-softfp-compat"
 diff --git a/libgcc/config/i386/64/t-zephyr64 b/libgcc/config/i386/64/t-zephyr64
 new file mode 100644
-index 00000000000..7595cdeed84
+index 000000000..7595cdeed
 --- /dev/null
 +++ b/libgcc/config/i386/64/t-zephyr64
 @@ -0,0 +1 @@
 +HOST_LIBGCC2_CFLAGS += -mlong-double-80
+diff --git a/libgcc/configure b/libgcc/configure
+index 283703767..ff83b800e 100644
+--- a/libgcc/configure
++++ b/libgcc/configure
+@@ -4728,6 +4728,7 @@ else
+ 
+   case $host in
+     powerpc*-*-linux* | i?86*-*-linux* | x86_64*-*-linux* | s390*-*-linux* | \
++    x86_64-zephyr-* | \
+     i?86*-*-elfiamcu | i?86*-*-gnu* | x86_64*-*-gnu* | \
+     i?86*-*-mingw* | x86_64*-*-mingw* | \
+     i?86*-*-cygwin* | x86_64*-*-cygwin*)
+diff --git a/libgfortran/configure b/libgfortran/configure
+index 60867b93d..93e95e0fc 100755
+--- a/libgfortran/configure
++++ b/libgfortran/configure
+@@ -8423,7 +8423,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -8438,7 +8438,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -8467,7 +8467,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
+diff --git a/libgomp/configure b/libgomp/configure
+index b4bc4f436..a64eab0d6 100755
+--- a/libgomp/configure
++++ b/libgomp/configure
+@@ -6880,7 +6880,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -6895,7 +6895,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -6924,7 +6924,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
+diff --git a/libhsail-rt/configure b/libhsail-rt/configure
+index 6a086102d..ac7788c77 100755
+--- a/libhsail-rt/configure
++++ b/libhsail-rt/configure
+@@ -6695,7 +6695,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -6710,7 +6710,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -6739,7 +6739,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
+diff --git a/libitm/configure b/libitm/configure
+index fb742d79e..69c78242f 100644
+--- a/libitm/configure
++++ b/libitm/configure
+@@ -7518,7 +7518,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -7533,7 +7533,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -7562,7 +7562,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
+diff --git a/libphobos/configure b/libphobos/configure
+index e2977b3cc..6f4defed2 100755
+--- a/libphobos/configure
++++ b/libphobos/configure
+@@ -7390,7 +7390,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -7405,7 +7405,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -7434,7 +7434,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
+diff --git a/libquadmath/configure b/libquadmath/configure
+index 5283adbdd..d028d364f 100755
+--- a/libquadmath/configure
++++ b/libquadmath/configure
+@@ -6526,7 +6526,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -6541,7 +6541,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -6570,7 +6570,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
+diff --git a/libsanitizer/configure b/libsanitizer/configure
+index 226da62cf..cb0c6160c 100755
+--- a/libsanitizer/configure
++++ b/libsanitizer/configure
+@@ -8084,7 +8084,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -8099,7 +8099,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -8128,7 +8128,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
+diff --git a/libssp/configure b/libssp/configure
+index 2adbcc3fc..9a3761ae7 100755
+--- a/libssp/configure
++++ b/libssp/configure
+@@ -6708,7 +6708,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -6723,7 +6723,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -6752,7 +6752,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
+diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
+index 5acf79cba..3aad84e30 100755
+--- a/libstdc++-v3/configure
++++ b/libstdc++-v3/configure
+@@ -7438,7 +7438,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -7453,7 +7453,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -7482,7 +7482,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
+diff --git a/libstdc++-v3/configure.host b/libstdc++-v3/configure.host
+index f2ff1295d..437c4954f 100644
+--- a/libstdc++-v3/configure.host
++++ b/libstdc++-v3/configure.host
+@@ -327,6 +327,15 @@ esac
+ # Set any OS-dependent and CPU-dependent bits.
+ # THIS TABLE IS SORTED.  KEEP IT THAT WAY.
+ case "${host}" in
++  *-zephyr-elf*)
++    case "${host_cpu}" in
++      i[567]86)
++        abi_baseline_pair=i486-zephyr-elf
++        ;;
++      x86_64)
++        abi_baseline_pair=x86_64-zephyr-elf
++        ;;
++    esac
+   *-*-linux*)
+     case "${host_cpu}" in
+       i[567]86)
+diff --git a/libtool.m4 b/libtool.m4
+index 896676288..0eda459e1 100644
+--- a/libtool.m4
++++ b/libtool.m4
+@@ -1220,7 +1220,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -1231,7 +1231,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -1260,7 +1260,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
+diff --git a/libvtv/configure b/libvtv/configure
+index bfdf34954..37a9b581b 100755
+--- a/libvtv/configure
++++ b/libvtv/configure
+@@ -7985,7 +7985,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -8000,7 +8000,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -8029,7 +8029,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
+diff --git a/lto-plugin/configure b/lto-plugin/configure
+index 8fdcab96d..c94489680 100755
+--- a/lto-plugin/configure
++++ b/lto-plugin/configure
+@@ -7520,7 +7520,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -7535,7 +7535,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -7564,7 +7564,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
+diff --git a/zlib/configure b/zlib/configure
+index 7a8b49b0b..9325722c5 100755
+--- a/zlib/configure
++++ b/zlib/configure
+@@ -6097,7 +6097,7 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   # Find out which ABI we are using.
+   echo 'int i;' > conftest.$ac_ext
+@@ -6112,7 +6112,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    case `/usr/bin/file conftest.o` in
+ 	      *x86-64*)
+ 		LD="${LD-ld} -m elf32_x86_64"
+@@ -6141,7 +6141,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+-	  x86_64-*linux*)
++	  x86_64-*linux*|x86_64-zephyr-*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+ 	  powerpcle-*linux*)
 -- 
-2.20.1
+2.21.0
 

--- a/patches/newlib/3.1.0.20181231/0002-Recognize-x86_64-zephyr.patch
+++ b/patches/newlib/3.1.0.20181231/0002-Recognize-x86_64-zephyr.patch
@@ -1,14 +1,16 @@
-From bf9162f855ebb9c55f184b28bf1a4b477cafb3e6 Mon Sep 17 00:00:00 2001
+From 337c5a644abc6b2cb380f453a5185bcfd47f1ba3 Mon Sep 17 00:00:00 2001
 From: Daniel Leung <daniel.leung@intel.com>
 Date: Tue, 19 Mar 2019 18:27:16 -0700
-Subject: [PATCH 2/3] Recognize x86_64-*-elf
+Subject: [PATCH 2/3] Recognize x86_64-zephyr-*
 
-This extends the configure scripts to recognize x86_64-*-elf
+This extends the configure scripts to recognize x86_64-zephyr-*
 for multilib support.
 
 Signed-off-by: Daniel Leung <daniel.leung@intel.com>
 ---
  config/dfp.m4                                             | 2 +-
+ configure                                                 | 2 +-
+ configure.ac                                              | 2 +-
  libtool.m4                                                | 6 +++---
  newlib/configure                                          | 6 +++---
  newlib/iconvdata/configure                                | 6 +++---
@@ -25,10 +27,10 @@ Signed-off-by: Daniel Leung <daniel.leung@intel.com>
  newlib/libm/configure                                     | 6 +++---
  newlib/libm/machine/configure                             | 6 +++---
  newlib/libm/machine/i386/configure                        | 6 +++---
- 17 files changed, 49 insertions(+), 49 deletions(-)
+ 19 files changed, 51 insertions(+), 51 deletions(-)
 
 diff --git a/config/dfp.m4 b/config/dfp.m4
-index 5b29089..8b167c9 100644
+index 5b29089..a8e1c64 100644
 --- a/config/dfp.m4
 +++ b/config/dfp.m4
 @@ -20,7 +20,7 @@ Valid choices are 'yes', 'bid', 'dpd', and 'no'.]) ;;
@@ -36,12 +38,38 @@ index 5b29089..8b167c9 100644
  [
    case $1 in
 -    powerpc*-*-linux* | i?86*-*-linux* | x86_64*-*-linux* | s390*-*-linux* | \
-+    powerpc*-*-linux* | i?86*-*-linux* | x86_64*-*-linux* | x86_64-*-elf | s390*-*-linux* | \
++    powerpc*-*-linux* | i?86*-*-linux* | x86_64*-*-linux* | x86_64-zephyr-* | s390*-*-linux* | \
      i?86*-*-elfiamcu | i?86*-*-gnu* | \
      i?86*-*-mingw* | x86_64*-*-mingw* | \
      i?86*-*-cygwin* | x86_64*-*-cygwin*)
+diff --git a/configure b/configure
+index 5db5270..6ef128e 100755
+--- a/configure
++++ b/configure
+@@ -7510,7 +7510,7 @@ fi
+ # Special user-friendly check for native x86_64-linux build, if
+ # multilib is not explicitly enabled.
+ case "$target:$have_compiler:$host:$target:$enable_multilib" in
+-  x86_64-*linux*:yes:$build:$build:)
++  x86_64-*linux*:yes:$build:$build: | x86_64-zephyr-elf:yes:$build:$build:)
+     # Make sure we have a development environment that handles 32-bit
+     dev64=no
+     echo "int main () { return 0; }" > conftest.c
+diff --git a/configure.ac b/configure.ac
+index cf856e5..36d478a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3109,7 +3109,7 @@ fi
+ # Special user-friendly check for native x86_64-linux build, if
+ # multilib is not explicitly enabled.
+ case "$target:$have_compiler:$host:$target:$enable_multilib" in
+-  x86_64-*linux*:yes:$build:$build:)
++  x86_64-*linux*:yes:$build:$build: | x86_64-zephyr-elf:yes:$build:$build:)
+     # Make sure we have a development environment that handles 32-bit
+     dev64=no
+     echo "int main () { return 0; }" > conftest.c
 diff --git a/libtool.m4 b/libtool.m4
-index 24d13f3..8ebf1d5 100644
+index 24d13f3..53a90a1 100644
 --- a/libtool.m4
 +++ b/libtool.m4
 @@ -1220,7 +1220,7 @@ ia64-*-hpux*)
@@ -49,7 +77,7 @@ index 24d13f3..8ebf1d5 100644
    ;;
  
 -x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
-+x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-*-elf|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
  s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
    # Find out which ABI we are using.
    echo 'int i;' > conftest.$ac_ext
@@ -58,7 +86,7 @@ index 24d13f3..8ebf1d5 100644
  	    LD="${LD-ld} -m elf_i386_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    case `/usr/bin/file conftest.o` in
  	      *x86-64*)
  		LD="${LD-ld} -m elf32_x86_64"
@@ -67,12 +95,12 @@ index 24d13f3..8ebf1d5 100644
  	    LD="${LD-ld} -m elf_x86_64_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    LD="${LD-ld} -m elf_x86_64"
  	    ;;
  	  powerpcle-*linux*)
 diff --git a/newlib/configure b/newlib/configure
-index 6eef23c..e0049b8 100755
+index 6eef23c..ea61835 100755
 --- a/newlib/configure
 +++ b/newlib/configure
 @@ -7329,7 +7329,7 @@ ia64-*-hpux*)
@@ -80,7 +108,7 @@ index 6eef23c..e0049b8 100755
    ;;
  
 -x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
-+x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-*-elf|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
  s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
    # Find out which ABI we are using.
    echo 'int i;' > conftest.$ac_ext
@@ -89,7 +117,7 @@ index 6eef23c..e0049b8 100755
  	    LD="${LD-ld} -m elf_i386_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    case `/usr/bin/file conftest.o` in
  	      *x86-64*)
  		LD="${LD-ld} -m elf32_x86_64"
@@ -98,12 +126,12 @@ index 6eef23c..e0049b8 100755
  	    LD="${LD-ld} -m elf_x86_64_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    LD="${LD-ld} -m elf_x86_64"
  	    ;;
  	  powerpcle-*linux*)
 diff --git a/newlib/iconvdata/configure b/newlib/iconvdata/configure
-index cfac613..e90d51e 100755
+index cfac613..d2c1bbf 100755
 --- a/newlib/iconvdata/configure
 +++ b/newlib/iconvdata/configure
 @@ -6932,7 +6932,7 @@ ia64-*-hpux*)
@@ -111,7 +139,7 @@ index cfac613..e90d51e 100755
    ;;
  
 -x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
-+x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-*-elf|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
  s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
    # Find out which ABI we are using.
    echo 'int i;' > conftest.$ac_ext
@@ -120,7 +148,7 @@ index cfac613..e90d51e 100755
  	    LD="${LD-ld} -m elf_i386_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    case `/usr/bin/file conftest.o` in
  	      *x86-64*)
  		LD="${LD-ld} -m elf32_x86_64"
@@ -129,12 +157,12 @@ index cfac613..e90d51e 100755
  	    LD="${LD-ld} -m elf_x86_64_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    LD="${LD-ld} -m elf_x86_64"
  	    ;;
  	  powerpcle-*linux*)
 diff --git a/newlib/libc/configure b/newlib/libc/configure
-index 0dc213e..5ddf0fe 100755
+index 0dc213e..8ad28ca 100755
 --- a/newlib/libc/configure
 +++ b/newlib/libc/configure
 @@ -7056,7 +7056,7 @@ ia64-*-hpux*)
@@ -142,7 +170,7 @@ index 0dc213e..5ddf0fe 100755
    ;;
  
 -x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
-+x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-*-elf|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
  s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
    # Find out which ABI we are using.
    echo 'int i;' > conftest.$ac_ext
@@ -151,7 +179,7 @@ index 0dc213e..5ddf0fe 100755
  	    LD="${LD-ld} -m elf_i386_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    case `/usr/bin/file conftest.o` in
  	      *x86-64*)
  		LD="${LD-ld} -m elf32_x86_64"
@@ -160,12 +188,12 @@ index 0dc213e..5ddf0fe 100755
  	    LD="${LD-ld} -m elf_x86_64_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    LD="${LD-ld} -m elf_x86_64"
  	    ;;
  	  powerpcle-*linux*)
 diff --git a/newlib/libc/machine/configure b/newlib/libc/machine/configure
-index f3229e9..443b534 100755
+index f3229e9..f2f4445 100755
 --- a/newlib/libc/machine/configure
 +++ b/newlib/libc/machine/configure
 @@ -6991,7 +6991,7 @@ ia64-*-hpux*)
@@ -173,7 +201,7 @@ index f3229e9..443b534 100755
    ;;
  
 -x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
-+x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-*-elf|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
  s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
    # Find out which ABI we are using.
    echo 'int i;' > conftest.$ac_ext
@@ -182,7 +210,7 @@ index f3229e9..443b534 100755
  	    LD="${LD-ld} -m elf_i386_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    case `/usr/bin/file conftest.o` in
  	      *x86-64*)
  		LD="${LD-ld} -m elf32_x86_64"
@@ -191,12 +219,12 @@ index f3229e9..443b534 100755
  	    LD="${LD-ld} -m elf_x86_64_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    LD="${LD-ld} -m elf_x86_64"
  	    ;;
  	  powerpcle-*linux*)
 diff --git a/newlib/libc/machine/i386/configure b/newlib/libc/machine/i386/configure
-index 34a14f7..aa799c1 100755
+index 34a14f7..c188030 100755
 --- a/newlib/libc/machine/i386/configure
 +++ b/newlib/libc/machine/i386/configure
 @@ -6934,7 +6934,7 @@ ia64-*-hpux*)
@@ -204,7 +232,7 @@ index 34a14f7..aa799c1 100755
    ;;
  
 -x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
-+x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-*-elf|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
  s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
    # Find out which ABI we are using.
    echo 'int i;' > conftest.$ac_ext
@@ -213,7 +241,7 @@ index 34a14f7..aa799c1 100755
  	    LD="${LD-ld} -m elf_i386_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    case `/usr/bin/file conftest.o` in
  	      *x86-64*)
  		LD="${LD-ld} -m elf32_x86_64"
@@ -222,12 +250,12 @@ index 34a14f7..aa799c1 100755
  	    LD="${LD-ld} -m elf_x86_64_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    LD="${LD-ld} -m elf_x86_64"
  	    ;;
  	  powerpcle-*linux*)
 diff --git a/newlib/libc/sys/configure b/newlib/libc/sys/configure
-index 08485a1..3b7338f 100755
+index 08485a1..a24e95d 100755
 --- a/newlib/libc/sys/configure
 +++ b/newlib/libc/sys/configure
 @@ -6963,7 +6963,7 @@ ia64-*-hpux*)
@@ -235,7 +263,7 @@ index 08485a1..3b7338f 100755
    ;;
  
 -x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
-+x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-*-elf|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
  s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
    # Find out which ABI we are using.
    echo 'int i;' > conftest.$ac_ext
@@ -244,7 +272,7 @@ index 08485a1..3b7338f 100755
  	    LD="${LD-ld} -m elf_i386_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    case `/usr/bin/file conftest.o` in
  	      *x86-64*)
  		LD="${LD-ld} -m elf32_x86_64"
@@ -253,12 +281,12 @@ index 08485a1..3b7338f 100755
  	    LD="${LD-ld} -m elf_x86_64_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    LD="${LD-ld} -m elf_x86_64"
  	    ;;
  	  powerpcle-*linux*)
 diff --git a/newlib/libc/sys/linux/configure b/newlib/libc/sys/linux/configure
-index 2ac7230..806a635 100755
+index 2ac7230..ac2e66b 100755
 --- a/newlib/libc/sys/linux/configure
 +++ b/newlib/libc/sys/linux/configure
 @@ -6980,7 +6980,7 @@ ia64-*-hpux*)
@@ -266,7 +294,7 @@ index 2ac7230..806a635 100755
    ;;
  
 -x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
-+x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-*-elf|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
  s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
    # Find out which ABI we are using.
    echo 'int i;' > conftest.$ac_ext
@@ -275,7 +303,7 @@ index 2ac7230..806a635 100755
  	    LD="${LD-ld} -m elf_i386_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    case `/usr/bin/file conftest.o` in
  	      *x86-64*)
  		LD="${LD-ld} -m elf32_x86_64"
@@ -284,12 +312,12 @@ index 2ac7230..806a635 100755
  	    LD="${LD-ld} -m elf_x86_64_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    LD="${LD-ld} -m elf_x86_64"
  	    ;;
  	  powerpcle-*linux*)
 diff --git a/newlib/libc/sys/linux/linuxthreads/configure b/newlib/libc/sys/linux/linuxthreads/configure
-index ca62ff1..a20ff72 100755
+index ca62ff1..83b3e3e 100755
 --- a/newlib/libc/sys/linux/linuxthreads/configure
 +++ b/newlib/libc/sys/linux/linuxthreads/configure
 @@ -6978,7 +6978,7 @@ ia64-*-hpux*)
@@ -297,7 +325,7 @@ index ca62ff1..a20ff72 100755
    ;;
  
 -x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
-+x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-*-elf|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
  s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
    # Find out which ABI we are using.
    echo 'int i;' > conftest.$ac_ext
@@ -306,7 +334,7 @@ index ca62ff1..a20ff72 100755
  	    LD="${LD-ld} -m elf_i386_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    case `/usr/bin/file conftest.o` in
  	      *x86-64*)
  		LD="${LD-ld} -m elf32_x86_64"
@@ -315,12 +343,12 @@ index ca62ff1..a20ff72 100755
  	    LD="${LD-ld} -m elf_x86_64_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    LD="${LD-ld} -m elf_x86_64"
  	    ;;
  	  powerpcle-*linux*)
 diff --git a/newlib/libc/sys/linux/linuxthreads/machine/configure b/newlib/libc/sys/linux/linuxthreads/machine/configure
-index dea024c..06f5a90 100755
+index dea024c..6b1b1c4 100755
 --- a/newlib/libc/sys/linux/linuxthreads/machine/configure
 +++ b/newlib/libc/sys/linux/linuxthreads/machine/configure
 @@ -6936,7 +6936,7 @@ ia64-*-hpux*)
@@ -328,7 +356,7 @@ index dea024c..06f5a90 100755
    ;;
  
 -x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
-+x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-*-elf|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
  s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
    # Find out which ABI we are using.
    echo 'int i;' > conftest.$ac_ext
@@ -337,7 +365,7 @@ index dea024c..06f5a90 100755
  	    LD="${LD-ld} -m elf_i386_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    case `/usr/bin/file conftest.o` in
  	      *x86-64*)
  		LD="${LD-ld} -m elf32_x86_64"
@@ -346,12 +374,12 @@ index dea024c..06f5a90 100755
  	    LD="${LD-ld} -m elf_x86_64_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    LD="${LD-ld} -m elf_x86_64"
  	    ;;
  	  powerpcle-*linux*)
 diff --git a/newlib/libc/sys/linux/linuxthreads/machine/i386/configure b/newlib/libc/sys/linux/linuxthreads/machine/i386/configure
-index 35a8c81..eed3874 100755
+index 35a8c81..39f9551 100755
 --- a/newlib/libc/sys/linux/linuxthreads/machine/i386/configure
 +++ b/newlib/libc/sys/linux/linuxthreads/machine/i386/configure
 @@ -6974,7 +6974,7 @@ ia64-*-hpux*)
@@ -359,7 +387,7 @@ index 35a8c81..eed3874 100755
    ;;
  
 -x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
-+x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-*-elf|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
  s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
    # Find out which ABI we are using.
    echo 'int i;' > conftest.$ac_ext
@@ -368,7 +396,7 @@ index 35a8c81..eed3874 100755
  	    LD="${LD-ld} -m elf_i386_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    case `/usr/bin/file conftest.o` in
  	      *x86-64*)
  		LD="${LD-ld} -m elf32_x86_64"
@@ -377,12 +405,12 @@ index 35a8c81..eed3874 100755
  	    LD="${LD-ld} -m elf_x86_64_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    LD="${LD-ld} -m elf_x86_64"
  	    ;;
  	  powerpcle-*linux*)
 diff --git a/newlib/libc/sys/linux/machine/configure b/newlib/libc/sys/linux/machine/configure
-index 359b7a3..b4aca37 100755
+index 359b7a3..fe112f6 100755
 --- a/newlib/libc/sys/linux/machine/configure
 +++ b/newlib/libc/sys/linux/machine/configure
 @@ -6937,7 +6937,7 @@ ia64-*-hpux*)
@@ -390,7 +418,7 @@ index 359b7a3..b4aca37 100755
    ;;
  
 -x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
-+x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-*-elf|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
  s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
    # Find out which ABI we are using.
    echo 'int i;' > conftest.$ac_ext
@@ -399,7 +427,7 @@ index 359b7a3..b4aca37 100755
  	    LD="${LD-ld} -m elf_i386_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    case `/usr/bin/file conftest.o` in
  	      *x86-64*)
  		LD="${LD-ld} -m elf32_x86_64"
@@ -408,12 +436,12 @@ index 359b7a3..b4aca37 100755
  	    LD="${LD-ld} -m elf_x86_64_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    LD="${LD-ld} -m elf_x86_64"
  	    ;;
  	  powerpcle-*linux*)
 diff --git a/newlib/libc/sys/linux/machine/i386/configure b/newlib/libc/sys/linux/machine/i386/configure
-index 48ebb68..819785a 100755
+index 48ebb68..34be4a9 100755
 --- a/newlib/libc/sys/linux/machine/i386/configure
 +++ b/newlib/libc/sys/linux/machine/i386/configure
 @@ -6974,7 +6974,7 @@ ia64-*-hpux*)
@@ -421,7 +449,7 @@ index 48ebb68..819785a 100755
    ;;
  
 -x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
-+x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-*-elf|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
  s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
    # Find out which ABI we are using.
    echo 'int i;' > conftest.$ac_ext
@@ -430,7 +458,7 @@ index 48ebb68..819785a 100755
  	    LD="${LD-ld} -m elf_i386_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    case `/usr/bin/file conftest.o` in
  	      *x86-64*)
  		LD="${LD-ld} -m elf32_x86_64"
@@ -439,12 +467,12 @@ index 48ebb68..819785a 100755
  	    LD="${LD-ld} -m elf_x86_64_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    LD="${LD-ld} -m elf_x86_64"
  	    ;;
  	  powerpcle-*linux*)
 diff --git a/newlib/libm/configure b/newlib/libm/configure
-index e8a0a99..dd94bcb 100755
+index e8a0a99..1f7fb34 100755
 --- a/newlib/libm/configure
 +++ b/newlib/libm/configure
 @@ -6996,7 +6996,7 @@ ia64-*-hpux*)
@@ -452,7 +480,7 @@ index e8a0a99..dd94bcb 100755
    ;;
  
 -x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
-+x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-*-elf|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
  s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
    # Find out which ABI we are using.
    echo 'int i;' > conftest.$ac_ext
@@ -461,7 +489,7 @@ index e8a0a99..dd94bcb 100755
  	    LD="${LD-ld} -m elf_i386_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    case `/usr/bin/file conftest.o` in
  	      *x86-64*)
  		LD="${LD-ld} -m elf32_x86_64"
@@ -470,12 +498,12 @@ index e8a0a99..dd94bcb 100755
  	    LD="${LD-ld} -m elf_x86_64_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    LD="${LD-ld} -m elf_x86_64"
  	    ;;
  	  powerpcle-*linux*)
 diff --git a/newlib/libm/machine/configure b/newlib/libm/machine/configure
-index 071a70c..f8b9c38 100755
+index 071a70c..fc80dad 100755
 --- a/newlib/libm/machine/configure
 +++ b/newlib/libm/machine/configure
 @@ -6942,7 +6942,7 @@ ia64-*-hpux*)
@@ -483,7 +511,7 @@ index 071a70c..f8b9c38 100755
    ;;
  
 -x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
-+x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-*-elf|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
  s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
    # Find out which ABI we are using.
    echo 'int i;' > conftest.$ac_ext
@@ -492,7 +520,7 @@ index 071a70c..f8b9c38 100755
  	    LD="${LD-ld} -m elf_i386_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    case `/usr/bin/file conftest.o` in
  	      *x86-64*)
  		LD="${LD-ld} -m elf32_x86_64"
@@ -501,12 +529,12 @@ index 071a70c..f8b9c38 100755
  	    LD="${LD-ld} -m elf_x86_64_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    LD="${LD-ld} -m elf_x86_64"
  	    ;;
  	  powerpcle-*linux*)
 diff --git a/newlib/libm/machine/i386/configure b/newlib/libm/machine/i386/configure
-index f2625be..57725fa 100755
+index f2625be..c8382b5 100755
 --- a/newlib/libm/machine/i386/configure
 +++ b/newlib/libm/machine/i386/configure
 @@ -6932,7 +6932,7 @@ ia64-*-hpux*)
@@ -514,7 +542,7 @@ index f2625be..57725fa 100755
    ;;
  
 -x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
-+x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-*-elf|powerpc*-*linux*| \
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|x86_64-zephyr-*|powerpc*-*linux*| \
  s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
    # Find out which ABI we are using.
    echo 'int i;' > conftest.$ac_ext
@@ -523,7 +551,7 @@ index f2625be..57725fa 100755
  	    LD="${LD-ld} -m elf_i386_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    case `/usr/bin/file conftest.o` in
  	      *x86-64*)
  		LD="${LD-ld} -m elf32_x86_64"
@@ -532,7 +560,7 @@ index f2625be..57725fa 100755
  	    LD="${LD-ld} -m elf_x86_64_fbsd"
  	    ;;
 -	  x86_64-*linux*)
-+	  x86_64-*linux* | x86_64-*-elf)
++	  x86_64-*linux* | x86_64-zephyr-*)
  	    LD="${LD-ld} -m elf_x86_64"
  	    ;;
  	  powerpcle-*linux*)

--- a/patches/newlib/3.1.0.20181231/0003-Support-building-for-32-bit-under-x86_64.patch
+++ b/patches/newlib/3.1.0.20181231/0003-Support-building-for-32-bit-under-x86_64.patch
@@ -1,4 +1,4 @@
-From 5d17ef2b46a5a0b5aaf7069b9eac4876699f7ade Mon Sep 17 00:00:00 2001
+From 245f1a8ff4395e5d4bda79cec59acf1e2e1ad5f2 Mon Sep 17 00:00:00 2001
 From: Daniel Leung <daniel.leung@intel.com>
 Date: Wed, 8 May 2019 09:17:10 -0700
 Subject: [PATCH 3/3] Support building for 32-bit under x86_64
@@ -9,14 +9,14 @@ x86_64.
 
 Signed-off-by: Daniel Leung <daniel.leung@intel.com>
 ---
- newlib/configure.host | 9 ++++++++-
- 1 file changed, 8 insertions(+), 1 deletion(-)
+ newlib/configure.host | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
 
 diff --git a/newlib/configure.host b/newlib/configure.host
-index 6c49cb7..1f66c96 100644
+index 6c49cb7..3587510 100644
 --- a/newlib/configure.host
 +++ b/newlib/configure.host
-@@ -333,7 +333,14 @@ case "${host_cpu}" in
+@@ -333,7 +333,17 @@ case "${host_cpu}" in
  	machine_dir=w65
  	;;
    x86_64)
@@ -24,6 +24,9 @@ index 6c49cb7..1f66c96 100644
 +	case "${CC}" in
 +	  *-m32)
 +	      machine_dir=i386
++	      ;;
++	  *-mx32)
++	      machine_dir=x86_64
 +	      ;;
 +	  *)
 +	      machine_dir=x86_64


### PR DESCRIPTION
* Ran autoreconf on library projects to support the x86_64-zephyr-elf tuple.
* Remove the check for multilib in configure as we are now hard-coding the MULTILIB_OPTIONS in t-zephyr64. The previos attempt was using the Linux version of t-linux64. That is targeting shared library placement for live system. Since Zephyr only needs the static libraries for linking purpose only, there is no need to put them under /lib or /lib64. So simplify it a bit.
* Set m64 as the default for multilib so it won't build 64-bit libraries twice (one under /lib, and one under /lib/64).
* Add LINK_SPEC to specify default binary format for final linking. This helps with compiler flag check with cmake as it does not know what format to use, and the default elf_x86_64 was being used to link both 32 and x32 targets. The check would fail as as the compiler would always try to link 64-bit libgcc.a even for 32-bit or x32 targets.
* Skip the need for crt0.o as there is no crt0.o for x86_64 targets. The absence of this file also causes compiler flag check failures.
* Set the default architecture for both 32-bit and 64-bit targets.