### PR TITLE
meta-zephyr-sdk: hidapi-libraw: add libusb1 as dependency

### DIFF
--- a/meta-zephyr-sdk/recipes-hosttools/hidapi/hidapi-libraw_0.8.bb
+++ b/meta-zephyr-sdk/recipes-hosttools/hidapi/hidapi-libraw_0.8.bb
@@ -5,7 +5,7 @@ SECTION = "libs"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://LICENSE-bsd.txt;md5=b5fa085ce0926bb50d0621620a82361f"
 
-DEPENDS += "udev"
+DEPENDS += "udev libusb1"
 RDEPENDS_${PN} += "udev"
 
 PR = "r0"


### PR DESCRIPTION
Building tools always fails on first pass where hidapi-libraw
cannot find libusb-1.0 during configure. So explicitly add
libusb1 as dependency for hidapi-libraw so it won't fail.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>