### PR TITLE
Add arm-generic-fdt machine support in qemu-system-aarch64

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0001-qemu-nios2-Add-Altera-MAX-10-board-support-for-Zephy.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0001-qemu-nios2-Add-Altera-MAX-10-board-support-for-Zephy.patch
@@ -30,7 +30,7 @@ new file mode 100644
 index 0000000000..a3329a9288
 --- /dev/null
 +++ b/hw/nios2/altera_10m50_zephyr.c
-@@ -0,0 +1,163 @@
+@@ -0,0 +1,165 @@
 +/*
 + * Copyright (c) 2018 Intel Corporation
 + *
@@ -49,7 +49,9 @@ index 0000000000..a3329a9288
 +#include "cpu.h"
 +#include "hw/sysbus.h"
 +#include "hw/hw.h"
++#include "hw/qdev-properties.h"
 +#include "hw/char/serial.h"
++#include "sysemu/reset.h"
 +#include "sysemu/sysemu.h"
 +#include "hw/boards.h"
 +#include "hw/loader.h"

--- a/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
@@ -9,6 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
 SRCREV = "9e06029aea3b2eca1d5261352e695edc1e7d7b8b"
 SRC_URI = "git://github.com/qemu/qemu.git;protocol=https \
 	   file://0001-qemu-nios2-Add-Altera-MAX-10-board-support-for-Zephy.patch \
+	   file://0002-add-arm-generic-fdt-from-xilinx-fork.patch \
 "
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
This commit adds a patch to support the arm-generic-fdt machine type
in qemu-system-aarch64. The arm-generic-fdt machine type is currently
available only in the Xilinx QEMU fork and this patch was generated by
diff-ing the QEMU 4.1 release and the master_next branch of the Xilinx
fork (which is based on the QEMU 4.1 release).

This machine type is required to properly emulate the Xilinx Zynq SoCs
used by the qemu_cortex_r5 platform.

For more details, refer to the issue #132.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

This closes #132.