### PR TITLE
Add Xilinx QEMU (qemu-system-xilinx-aarch64)

### DIFF
--- a/meta-zephyr-sdk/recipes-hosttools/hosttools/hosttools-tarball.bb
+++ b/meta-zephyr-sdk/recipes-hosttools/hosttools/hosttools-tarball.bb
@@ -8,6 +8,7 @@ TOOLCHAIN_TARGET_TASK ?= ""
 
 TOOLCHAIN_HOST_TASK ?= "\
     nativesdk-zephyr-qemu \
+    nativesdk-xilinx-qemu \
     nativesdk-openocd \
     nativesdk-bossa \
     nativesdk-dtc \


### PR DESCRIPTION
This commit adds Xilinx QEMU recipe for building AArch64 QEMU
(qemu-system-xilinx-aarch64).

The Xilinx QEMU fork is necessary because the arm-generic-fdt machine
type, required to properly emulate the Xilinx Zynq SoC, is only
availabe on it at this time.

For more details, refer to the issue #132.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>