### PR TITLE
scripts/make_zephyr_sdk: fix for arm v arm64

### DIFF
--- a/scripts/make_zephyr_sdk.sh
+++ b/scripts/make_zephyr_sdk.sh
@@ -35,17 +35,21 @@ parse_toolchain_name()
     local num
     local filename
 
-    num=$(ls toolchains | grep $arch | wc -l)
-    if [ "$num" -gt "1" ]; then
-        echo "Error: Multiple toolchains for \"$arch\" "
-        exit 1
-    fi
+    if [ -f toolchains/$arch.tar.bz2 ]; then
+	filename="toolchains/$arch.tar.bz2"
+    else
+        num=$(ls toolchains | grep $arch | wc -l)
+        if [ "$num" -gt "1" ]; then
+            echo "Error: Multiple toolchains for \"$arch\" "
+            exit 1
+        fi
 
-    if [ "$num" -eq "0" ]; then
-        echo "Warning: Missing toolchain for \"$arch\" "
-    fi
+        if [ "$num" -eq "0" ]; then
+            echo "Warning: Missing toolchain for \"$arch\" "
+        fi
 
-    filename=$(ls toolchains | grep $arch)
+        filename=$(ls toolchains | grep $arch)
+    fi
     eval "$varname=\$filename"
 }
 


### PR DESCRIPTION
We hit an error case when we added arm64, fix the handling of how we
determine the toolchain file name.  First guess that it is $arch.tar.bz2
and if not fall back to the old style check (which will get used for the
host tools).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>