### PR TITLE
scripts: change umask if we are installing as root to fix dir perms

### DIFF
--- a/scripts/template_dir
+++ b/scripts/template_dir
@@ -223,8 +223,8 @@ fi
 
 if (( EUID != 0 )); then
 	umask 0002
-#else
-#	umask 0022
+else
+	umask 0022
 fi
 
 


### PR DESCRIPTION
Since we now install the xtensa toolchains under xtensa/ we need the
umask to be 0022 if EUID == 0.  Otherwise we can't access the xtensa
install dir.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>