### PR TITLE
gdb/remote: Fix write_ptid tid/pid overflow

### DIFF
--- a/patches/gdb/8.3.1/0001-gdb-remote-make-tid-pid-type-long-in-wite_ptid.patch
+++ b/patches/gdb/8.3.1/0001-gdb-remote-make-tid-pid-type-long-in-wite_ptid.patch
@@ -1,0 +1,54 @@
+From ea3cc3102326d6e6c4ede80d6a9fa8c0a99ff4e9 Mon Sep 17 00:00:00 2001
+From: Evgeniy Didin <didin@synopsys.com>
+Date: Thu, 7 Nov 2019 08:58:58 +0300
+Subject: [PATCH] gdb/remote: make tid/pid type long in write_ptid
+
+In Zephyr RTOS the k_thread_create function returns
+thread ID which is actually pointer to k_thread structure.
+If the memory addressing starts from 0x80000000, passing such
+big values to write_ptid() leads to overflow of "int tid" variable
+and thread ID becomes negative.
+So lets make tid/pid variables type "long", this will prevent overflow
+and should not break any logic.
+
+Signed-off-by: Evgeniy Didin <didin@synopsys.com>
+
+---
+ gdb/remote.c  | 10 +++++-----
+ 1 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/gdb/remote.c b/gdb/remote.c
+index 1ac9013408..19602508f7 100644
+--- a/gdb/remote.c
++++ b/gdb/remote.c
+@@ -2909,22 +2909,22 @@ static int remote_newthread_step (threadref *ref, void *context);
+ char *
+ remote_target::write_ptid (char *buf, const char *endbuf, ptid_t ptid)
+ {
+-  int pid, tid;
++  long pid, tid;
+   struct remote_state *rs = get_remote_state ();
+ 
+   if (remote_multi_process_p (rs))
+     {
+       pid = ptid.pid ();
+       if (pid < 0)
+-	buf += xsnprintf (buf, endbuf - buf, "p-%x.", -pid);
++	buf += xsnprintf (buf, endbuf - buf, "p-%lx.", -pid);
+       else
+-	buf += xsnprintf (buf, endbuf - buf, "p%x.", pid);
++	buf += xsnprintf (buf, endbuf - buf, "p%lx.", pid);
+     }
+   tid = ptid.lwp ();
+   if (tid < 0)
+-    buf += xsnprintf (buf, endbuf - buf, "-%x", -tid);
++    buf += xsnprintf (buf, endbuf - buf, "-%lx", -tid);
+   else
+-    buf += xsnprintf (buf, endbuf - buf, "%x", tid);
++    buf += xsnprintf (buf, endbuf - buf, "%lx", tid);
+ 
+   return buf;
+ }
+-- 
+2.17.2
+


### PR DESCRIPTION
For ARC in Zephyr RTOS TID's values start from 0x80000000.
Passing such big values to write_ptid function cause
overflow of "int tid" variable. As a result TID becomes
negative and trying to switch to such thread leads to such message:
	(gdb) thread xxx
	Thread ID xxx has terminated.

Adding this GDB patch fixes thread-aware debugging for Zephyr on ARC boards

Patch in patchwork:
http://patchwork.sourceware.org/patch/35764/

Signed-off-by: Evgeniy Didin <didin@synopsys.com>