### PR TITLE
Add patches for building 'tools' with GCC 9

### DIFF
--- a/meta-zephyr-sdk/patches/gcc-9-0001-Fix-elfutils-for-GCC-9.patch
+++ b/meta-zephyr-sdk/patches/gcc-9-0001-Fix-elfutils-for-GCC-9.patch
@@ -1,0 +1,100 @@
+From fddc9161f20f6c5b6e9d9cfa6bf90944ddc39b55 Mon Sep 17 00:00:00 2001
+From: Stephanos Ioannidis <root@stephanos.io>
+Date: Tue, 10 Dec 2019 16:20:17 +0900
+Subject: [PATCH 1/2] Fix elfutils for GCC 9
+
+Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
+---
+ ...used-internal-__elf-32-64-_msize-fun.patch | 67 +++++++++++++++++++
+ .../elfutils/elfutils_0.166.bb                |  1 +
+ 2 files changed, 68 insertions(+)
+ create mode 100644 meta/recipes-devtools/elfutils/elfutils-0.166/0001-libelf-Remove-unused-internal-__elf-32-64-_msize-fun.patch
+
+diff --git a/meta/recipes-devtools/elfutils/elfutils-0.166/0001-libelf-Remove-unused-internal-__elf-32-64-_msize-fun.patch b/meta/recipes-devtools/elfutils/elfutils-0.166/0001-libelf-Remove-unused-internal-__elf-32-64-_msize-fun.patch
+new file mode 100644
+index 0000000000..1b3096f508
+--- /dev/null
++++ b/meta/recipes-devtools/elfutils/elfutils-0.166/0001-libelf-Remove-unused-internal-__elf-32-64-_msize-fun.patch
+@@ -0,0 +1,67 @@
++From 04cb1c56d923cbf9cf0d0399da445b117de95cb4 Mon Sep 17 00:00:00 2001
++From: Mark Wielaard <mark@klomp.org>
++Date: Fri, 22 Feb 2019 00:28:01 +0100
++Subject: [PATCH] libelf: Remove unused internal __elf[32|64]_msize functions.
++
++Those functions were intended for ELF versions where the memory and
++file sizes of data structures are different. They were never used
++because libelf depends on the file and memory sizes being equal
++(otherwise using mmap wouldn't work).
++
++Signed-off-by: Mark Wielaard <mark@klomp.org>
++(cherry picked from commit be8080bdd746ac2b07fb0bcad23a9677844bb200)
++---
++ libelf/ChangeLog     |  7 +++++++
++ libelf/elf32_fsize.c |  2 --
++ libelf/libelfP.h     | 10 ----------
++ 3 files changed, 7 insertions(+), 12 deletions(-)
++
++diff --git a/libelf/ChangeLog b/libelf/ChangeLog
++index 350e4eb1..e6fce196 100644
++--- a/libelf/ChangeLog
+++++ b/libelf/ChangeLog
++@@ -1,3 +1,10 @@
+++2019-02-24  Mark Wielaard  <mark@klomp.org>
+++
+++	* elf32_fsize.c (local_strong_alias): Remove definition.
+++	(msize): Remove alias.
+++	* libelfP.h (__elf32_msize): Remove definition.
+++	(__elf64_msize): Likewise.
+++
++ 2016-02-13  Mark Wielaard  <mjw@redhat.com>
++ 
++ 	* elf32_updatefile.c (updatemmap): Free scns when out of memory.
++diff --git a/libelf/elf32_fsize.c b/libelf/elf32_fsize.c
++index fddae91e..16919daa 100644
++--- a/libelf/elf32_fsize.c
+++++ b/libelf/elf32_fsize.c
++@@ -64,5 +64,3 @@ elfw2(LIBELFBITS, fsize) (Elf_Type type, size_t count, unsigned int version)
++ 	  * __libelf_type_sizes[0][ELFW(ELFCLASS,LIBELFBITS) - 1][type]);
++ #endif
++ }
++-#define local_strong_alias(n1, n2) strong_alias (n1, n2)
++-local_strong_alias (elfw2(LIBELFBITS, fsize), __elfw2(LIBELFBITS, msize))
++diff --git a/libelf/libelfP.h b/libelf/libelfP.h
++index 57ccbce4..6292824d 100644
++--- a/libelf/libelfP.h
+++++ b/libelf/libelfP.h
++@@ -455,16 +455,6 @@ extern const uint_fast8_t __libelf_type_aligns[EV_NUM - 1][ELFCLASSNUM - 1][ELF_
++    be ELF_T_BYTE.  */
++ extern Elf_Type __libelf_data_type (Elf *elf, int sh_type) internal_function;
++ 
++-/* The libelf API does not have such a function but it is still useful.
++-   Get the memory size for the given type.
++-
++-   These functions cannot be marked internal since they are aliases
++-   of the export elfXX_fsize functions.*/
++-extern size_t __elf32_msize (Elf_Type __type, size_t __count,
++-			     unsigned int __version);
++-extern size_t __elf64_msize (Elf_Type __type, size_t __count,
++-			     unsigned int __version);
++-
++ 
++ /* Create Elf descriptor from memory image.  */
++ extern Elf *__libelf_read_mmaped_file (int fildes, void *map_address,
++-- 
++2.17.1
++
+diff --git a/meta/recipes-devtools/elfutils/elfutils_0.166.bb b/meta/recipes-devtools/elfutils/elfutils_0.166.bb
+index 5c436d3864..8ac4890402 100644
+--- a/meta/recipes-devtools/elfutils/elfutils_0.166.bb
++++ b/meta/recipes-devtools/elfutils/elfutils_0.166.bb
+@@ -19,6 +19,7 @@ SRC_URI += "\
+         file://0001-fix-a-stack-usage-warning.patch \
+         file://aarch64_uio.patch \
+         file://shadow.patch \
++        file://0001-libelf-Remove-unused-internal-__elf-32-64-_msize-fun.patch \
+ "
+ 
+ # pick the patch from debian
+-- 
+2.17.1
+

--- a/meta-zephyr-sdk/patches/gcc-9-0002-Fix-glib-2.0-for-GCC-9.patch
+++ b/meta-zephyr-sdk/patches/gcc-9-0002-Fix-glib-2.0-for-GCC-9.patch
@@ -1,0 +1,106 @@
+From 1b1de0670e587a37b5ed7f6f10a3d72018d271d9 Mon Sep 17 00:00:00 2001
+From: Stephanos Ioannidis <root@stephanos.io>
+Date: Tue, 10 Dec 2019 16:22:18 +0900
+Subject: [PATCH 2/2] Fix glib-2.0 for GCC 9
+
+Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
+---
+ ...01-gdbus-Avoid-printing-null-strings.patch | 73 +++++++++++++++++++
+ meta/recipes-core/glib-2.0/glib-2.0_2.48.2.bb |  1 +
+ 2 files changed, 74 insertions(+)
+ create mode 100644 meta/recipes-core/glib-2.0/glib-2.0/0001-gdbus-Avoid-printing-null-strings.patch
+
+diff --git a/meta/recipes-core/glib-2.0/glib-2.0/0001-gdbus-Avoid-printing-null-strings.patch b/meta/recipes-core/glib-2.0/glib-2.0/0001-gdbus-Avoid-printing-null-strings.patch
+new file mode 100644
+index 0000000000..7783ea0451
+--- /dev/null
++++ b/meta/recipes-core/glib-2.0/glib-2.0/0001-gdbus-Avoid-printing-null-strings.patch
+@@ -0,0 +1,73 @@
++From 6d55964a0cce38c6ad265a05280025ca0ce1aa51 Mon Sep 17 00:00:00 2001
++From: Ernestas Kulik <ekulik@redhat.com>
++Date: Tue, 29 Jan 2019 09:50:46 +0100
++Subject: [PATCH] gdbus: Avoid printing null strings
++MIME-Version: 1.0
++Content-Type: text/plain; charset=UTF-8
++Content-Transfer-Encoding: 8bit
++
++This mostly affects the 2.56 branch, but, given that GCC 9 is being
++stricter about passing null string pointers to printf-like functions, it
++might make sense to proactively fix such calls.
++
++gdbusauth.c: In function '_g_dbus_auth_run_server':
++gdbusauth.c:1302:11: error: '%s' directive argument is null
++[-Werror=format-overflow=]
++ 1302 |           debug_print ("SERVER: WaitingForBegin, read '%s'",
++ line);
++       |
++
++gdbusmessage.c: In function ‘g_dbus_message_to_blob’:
++gdbusmessage.c:2730:30: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
++ 2730 |       tupled_signature_str = g_strdup_printf ("(%s)", signature_str);
++      |
++
++(cherry picked from commit 566e1d61a500267c7849ad0b2552feec9c9a29a6)
++---
++ gio/gdbusauth.c    | 2 +-
++ gio/gdbusmessage.c | 5 ++---
++ 2 files changed, 3 insertions(+), 4 deletions(-)
++
++diff --git a/gio/gdbusauth.c b/gio/gdbusauth.c
++index 4036d778a..05ab1a98e 100644
++--- a/gio/gdbusauth.c
+++++ b/gio/gdbusauth.c
++@@ -1295,9 +1295,9 @@ _g_dbus_auth_run_server (GDBusAuth              *auth,
++                                                     &line_length,
++                                                     cancellable,
++                                                     error);
++-          debug_print ("SERVER: WaitingForBegin, read '%s'", line);
++           if (line == NULL)
++             goto out;
+++          debug_print ("SERVER: WaitingForBegin, read '%s'", line);
++           if (g_strcmp0 (line, "BEGIN") == 0)
++             {
++               /* YAY, done! */
++diff --git a/gio/gdbusmessage.c b/gio/gdbusmessage.c
++index d9d8f3726..bb1b8d337 100644
++--- a/gio/gdbusmessage.c
+++++ b/gio/gdbusmessage.c
++@@ -2695,7 +2695,6 @@ g_dbus_message_to_blob (GDBusMessage          *message,
++   if (message->body != NULL)
++     {
++       gchar *tupled_signature_str;
++-      tupled_signature_str = g_strdup_printf ("(%s)", signature_str);
++       if (signature == NULL)
++         {
++           g_set_error (error,
++@@ -2703,10 +2702,10 @@ g_dbus_message_to_blob (GDBusMessage          *message,
++                        G_IO_ERROR_INVALID_ARGUMENT,
++                        _("Message body has signature '%s' but there is no signature header"),
++                        signature_str);
++-          g_free (tupled_signature_str);
++           goto out;
++         }
++-      else if (g_strcmp0 (tupled_signature_str, g_variant_get_type_string (message->body)) != 0)
+++      tupled_signature_str = g_strdup_printf ("(%s)", signature_str);
+++      if (g_strcmp0 (tupled_signature_str, g_variant_get_type_string (message->body)) != 0)
++         {
++           g_set_error (error,
++                        G_IO_ERROR,
++-- 
++2.17.1
++
+diff --git a/meta/recipes-core/glib-2.0/glib-2.0_2.48.2.bb b/meta/recipes-core/glib-2.0/glib-2.0_2.48.2.bb
+index a45f644448..d9c33ea4fc 100644
+--- a/meta/recipes-core/glib-2.0/glib-2.0_2.48.2.bb
++++ b/meta/recipes-core/glib-2.0/glib-2.0_2.48.2.bb
+@@ -17,6 +17,7 @@ SRC_URI = "${GNOME_MIRROR}/glib/${SHRT_VER}/glib-${PV}.tar.xz \
+            file://0001-Install-gio-querymodules-as-libexec_PROGRAM.patch \
+            file://0001-Do-not-ignore-return-value-of-write.patch \
+            file://0002-tests-Ignore-y2k-warnings.patch \
++           file://0001-gdbus-Avoid-printing-null-strings.patch \
+            "
+ 
+ SRC_URI_append_class-native = " file://glib-gettextize-dir.patch \
+-- 
+2.17.1
+


### PR DESCRIPTION
This commit adds a set of patches to allow building the 'tools' with
GCC 9.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>