### PR TITLE
arm64: Enable arm-zephyr-eabi multi-arch support for gdb

### DIFF
--- a/configs/arm64.config
+++ b/configs/arm64.config
@@ -37,5 +37,6 @@ CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-arra
 CT_CC_LANG_CXX=y
 CT_CC_GCC_LIBSTDCXX_NANO=y
 CT_DEBUG_GDB=y
+CT_GDB_CROSS_EXTRA_CONFIG_ARRAY="--enable-targets=arm-zephyr-eabi"
 CT_ISL_V_0_18=y
 CT_LIBICONV_NEEDED=y


### PR DESCRIPTION
This commit enables the "arm-zephyr-eabi" target support in the AArch64
gdb in order to support the devices that integrate both ARMv7 and ARMv8
cores into single system-on-chip (e.g. Xilinx Zynq UltraScale+ and TI
AM65x devices).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Related discussion at https://github.com/zephyrproject-rtos/zephyr/issues/20217#issuecomment-565871161.