### PR TITLE
xilinx_qemu: Fix WFI instruction

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/xilinx_qemu/files/0001-Revert-target-arm-Revert-back-to-YIELD-for-WFI.patch
+++ b/meta-zephyr-sdk/recipes-devtools/xilinx_qemu/files/0001-Revert-target-arm-Revert-back-to-YIELD-for-WFI.patch
@@ -1,0 +1,39 @@
+From 4bde2c46a979ba1539c05ffa6d4fc22ab6a2a9c2 Mon Sep 17 00:00:00 2001
+From: Stephanos Ioannidis <root@stephanos.io>
+Date: Wed, 8 Jan 2020 17:47:05 +0900
+Subject: [PATCH] Revert "target/arm: Revert back to YIELD for WFI"
+
+This reverts commit 5f38ea92fb697b94ad43f01fe162f3ed6e6b0e16.
+
+The commit 5f38ea92fb697b94ad43f01fe162f3ed6e6b0e16 was probably
+introduced in order to improve emulation performance, as well as to
+address the stability issue when running co-simulations (refer to the
+commit 708639f72be2a9425992ae9dc4b9a098dc804c94).
+
+This, unfortunately, breaks the WFI instruction; i.e. CPU is not halted
+and keeps running regardless of whether an interrupt occurs, and this
+is a problem for the Zephyr CI tests that expect the WFI instruction to
+do its job (in particular, tests/kernel/context is broken because of
+this change).
+
+Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
+---
+ target/arm/op_helper.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/target/arm/op_helper.c b/target/arm/op_helper.c
+index acef79251d..6ab3a75a76 100644
+--- a/target/arm/op_helper.c
++++ b/target/arm/op_helper.c
+@@ -304,7 +304,7 @@ void HELPER(wfi)(CPUARMState *env, uint32_t insn_len)
+     }
+ 
+     qemu_mutex_lock_iothread();
+-    if (use_icount || 1) {
++    if (use_icount) {
+         cs->exception_index = EXCP_YIELD;
+     } else {
+         cs->halted = 1;
+-- 
+2.17.1
+

--- a/meta-zephyr-sdk/recipes-devtools/xilinx_qemu/xilinx-qemu_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/xilinx_qemu/xilinx-qemu_git.bb
@@ -5,7 +5,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
                     file://COPYING.LIB;endline=24;md5=8c5efda6cf1e1b03dcfd0e6c0d271c7f"
 
-SRCREV = "b1aa9923432b55765d3dc3a93d8398783887233e"
+SRCREV = "293badb9e42930393d2246cbc4d0eb78409243ba"
 SRC_URI = "git://github.com/Xilinx/qemu.git;protocol=https \
 "
 

--- a/meta-zephyr-sdk/recipes-devtools/xilinx_qemu/xilinx-qemu_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/xilinx_qemu/xilinx-qemu_git.bb
@@ -7,6 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
 
 SRCREV = "293badb9e42930393d2246cbc4d0eb78409243ba"
 SRC_URI = "git://github.com/Xilinx/qemu.git;protocol=https \
+	   file://0001-Revert-target-arm-Revert-back-to-YIELD-for-WFI.patch \
 "
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
```
The Xilinx QEMU deliberately breaks the WFI (wake up from interrupt)
instruction, possibly for performance and cosimulation stability
reasons, and this causes the Zephyr CI tests, that expect the WFI
instruction to function properly, to fail.

This commit adds a patch to revert the offending Xilinx QEMU commit
since accurate simulation behaviour takes precedence over performance
for CI testing, and the Zephyr will not use the cosimulation feature.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
```

This PR includes a commit from the PR #163 (closes #163 if merged before).