### PR TITLE
xilinx_qemu: Fix WFI instruction for icount mode

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/xilinx_qemu/files/0001-Revert-target-arm-Revert-back-to-YIELD-for-WFI.patch
+++ b/meta-zephyr-sdk/recipes-devtools/xilinx_qemu/files/0001-Revert-target-arm-Revert-back-to-YIELD-for-WFI.patch
@@ -1,7 +1,7 @@
-From 4bde2c46a979ba1539c05ffa6d4fc22ab6a2a9c2 Mon Sep 17 00:00:00 2001
+From ef1724e0a558a0f6bc93530114173955bf67cf30 Mon Sep 17 00:00:00 2001
 From: Stephanos Ioannidis <root@stephanos.io>
 Date: Wed, 8 Jan 2020 17:47:05 +0900
-Subject: [PATCH] Revert "target/arm: Revert back to YIELD for WFI"
+Subject: [PATCH 1/2] Revert "target/arm: Revert back to YIELD for WFI"
 
 This reverts commit 5f38ea92fb697b94ad43f01fe162f3ed6e6b0e16.
 

--- a/meta-zephyr-sdk/recipes-devtools/xilinx_qemu/files/0002-Enable-WFI-CPU-halting-in-icount-mode.patch
+++ b/meta-zephyr-sdk/recipes-devtools/xilinx_qemu/files/0002-Enable-WFI-CPU-halting-in-icount-mode.patch
@@ -1,0 +1,39 @@
+From 6d7ce4d6e5ab8d4222bb41b4e09e3437d534481a Mon Sep 17 00:00:00 2001
+From: Stephanos Ioannidis <root@stephanos.io>
+Date: Wed, 26 Feb 2020 12:30:55 +0900
+Subject: [PATCH 2/2] Enable WFI CPU halting in icount mode
+
+This commit enables CPU halting via the WFI instruction in the
+icount mode.
+
+The PetaLinux patch initially disabled WFI CPU halting, possibly for
+performance reasons.
+
+Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
+---
+ target/arm/op_helper.c | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/target/arm/op_helper.c b/target/arm/op_helper.c
+index 6ab3a75a76..1199288fdd 100644
+--- a/target/arm/op_helper.c
++++ b/target/arm/op_helper.c
+@@ -304,12 +304,9 @@ void HELPER(wfi)(CPUARMState *env, uint32_t insn_len)
+     }
+ 
+     qemu_mutex_lock_iothread();
+-    if (use_icount) {
+-        cs->exception_index = EXCP_YIELD;
+-    } else {
+-        cs->halted = 1;
+-        cs->exception_index = EXCP_HLT;
+-    }
++
++    cs->halted = 1;
++    cs->exception_index = EXCP_HLT;
+ 
+     /* Drive STANDBYWFI only if cpu reset-pin is inactive */
+     if (cs->reset_pin == false) {
+-- 
+2.17.1
+

--- a/meta-zephyr-sdk/recipes-devtools/xilinx_qemu/xilinx-qemu_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/xilinx_qemu/xilinx-qemu_git.bb
@@ -8,6 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
 SRCREV = "293badb9e42930393d2246cbc4d0eb78409243ba"
 SRC_URI = "git://github.com/Xilinx/qemu.git;protocol=https \
 	   file://0001-Revert-target-arm-Revert-back-to-YIELD-for-WFI.patch \
+	   file://0002-Enable-WFI-CPU-halting-in-icount-mode.patch \
 "
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
The Xilinx QEMU deliberately breaks the WFI (wake up from interrupt)
instruction when icount mode is used, possibly for performance and
cosimulation stability reasons, and this causes the Zephyr CI tests,
that expect the WFI instruction to function properly, to fail.

This commit adds a patch to enable the CPU halt behaviour of the WFI
instruction in the icount mode, since accurate simulation behaviour
takes precedence over performance for CI testing, and the Zephyr will
not use the cosimulation feature.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

This PR addresses the issue identified in https://github.com/zephyrproject-rtos/zephyr/pull/22904#issuecomment-591209160.