### PR TITLE
scripts: template_dir: setup: add -[no]rc arg

### DIFF
--- a/scripts/template_dir
+++ b/scripts/template_dir
@@ -2,7 +2,7 @@
 target_sdk_dir=""
 post_install_cleanup=1
 confirm=0
-rc_confirm=0
+rc_confirm=""
 
 usage () {
   cat << EOF
@@ -18,6 +18,9 @@ Options:
 
   -y
         Automatic yes to prompts; assume "yes" as answer to all prompts.
+
+  -[no]rc
+        Whether to create/update the ~/.zerphyrc file (prompt if not given)
 
 EOF
 }
@@ -64,6 +67,12 @@ while [ "$1" != "" ]; do
 		-y )
 			confirm="y";
 			rc_confirm="y";
+			;;
+		-rc )
+			rc_confirm="y";
+			;;
+		-norc )
+			rc_confirm="n";
 			;;
 		* )
 			echo "Error: Invalid argument \"$1\""
@@ -115,7 +124,7 @@ do_zephyrrc()
 	echo "     export ZEPHYR_TOOLCHAIN_VARIANT=zephyr"
 	echo "     export ZEPHYR_SDK_INSTALL_DIR=$target_sdk_dir"
 	echo
-	if [ "$rc_confirm" != "y" ]; then
+	if [ -z "$rc_confirm" ]; then
 		echo "Update/Create $HOME/.zephyrrc with environment variables setup for you (y/n)? "
 		while read rc_confirm; do
 			[ "$rc_confirm" = "Y" -o "$rc_confirm" = "y" \


### PR DESCRIPTION
Needed for unattended setups that do not want to answer yes (with -y) to
the prompt about creating ~/.zephyrrc.

See Arch Linux package zephyr-sdk in AUR: 
https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=zephyr-sdk#n110