### PR TITLE
qemu: Add support for changing CPU type in sifive_e machine.

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0005-riscv-sifive_e-Support-changing-CPU-type.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0005-riscv-sifive_e-Support-changing-CPU-type.patch
@@ -1,0 +1,39 @@
+From 6bee5cdeb7ae297a997e23ab671beaaf3b3ebf58 Mon Sep 17 00:00:00 2001
+From: Corey Wharton <coreyw7@fb.com>
+Date: Thu, 12 Mar 2020 15:38:16 -0700
+Subject: [PATCH v2 1/2] riscv: sifive_e: Support changing CPU type
+
+Allows the CPU to be changed from the default via the -cpu command
+line option.
+
+Signed-off-by: Corey Wharton <coreyw7@fb.com>
+Reviewed-by: Bin Meng <bmeng.cn@gmail.com>
+Reviewed-by: Alistair Francis <alistair.francis@wdc.com>
+---
+ hw/riscv/sifive_e.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/hw/riscv/sifive_e.c b/hw/riscv/sifive_e.c
+index a254cad489..b0a611adb9 100644
+--- a/hw/riscv/sifive_e.c
++++ b/hw/riscv/sifive_e.c
+@@ -123,7 +123,7 @@ static void riscv_sifive_e_soc_init(Object *obj)
+     object_initialize_child(obj, "cpus", &s->cpus,
+                             sizeof(s->cpus), TYPE_RISCV_HART_ARRAY,
+                             &error_abort, NULL);
+-    object_property_set_str(OBJECT(&s->cpus), SIFIVE_E_CPU, "cpu-type",
++    object_property_set_str(OBJECT(&s->cpus), ms->cpu_type, "cpu-type",
+                             &error_abort);
+     object_property_set_int(OBJECT(&s->cpus), ms->smp.cpus, "num-harts",
+                             &error_abort);
+@@ -220,6 +220,7 @@ static void riscv_sifive_e_machine_init(MachineClass *mc)
+     mc->desc = "RISC-V Board compatible with SiFive E SDK";
+     mc->init = riscv_sifive_e_init;
+     mc->max_cpus = 1;
++    mc->default_cpu_type = SIFIVE_E_CPU;
+ }
+ 
+ DEFINE_MACHINE("sifive_e", riscv_sifive_e_machine_init)
+-- 
+2.21.1
+

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0006-target-riscv-Add-a-sifive-e34-cpu-type.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0006-target-riscv-Add-a-sifive-e34-cpu-type.patch
@@ -1,0 +1,59 @@
+From c9481f6ba0050a53411193b5a49bde6f2c4158b3 Mon Sep 17 00:00:00 2001
+From: Corey Wharton <coreyw7@fb.com>
+Date: Thu, 12 Mar 2020 16:43:02 -0700
+Subject: [PATCH v2 2/2] target/riscv: Add a sifive-e34 cpu type
+
+The sifive-e34 cpu type is the same as the sifive-e31 with the
+single precision floating-point extension enabled.
+
+Signed-off-by: Corey Wharton <coreyw7@fb.com>
+---
+v2: Added missing RVU flag
+
+ target/riscv/cpu.c | 10 ++++++++++
+ target/riscv/cpu.h |  1 +
+ 2 files changed, 11 insertions(+)
+
+diff --git a/target/riscv/cpu.c b/target/riscv/cpu.c
+index c0b7023100..1ae9d085b8 100644
+--- a/target/riscv/cpu.c
++++ b/target/riscv/cpu.c
+@@ -164,6 +164,15 @@ static void rv32imacu_nommu_cpu_init(Object *obj)
+     set_feature(env, RISCV_FEATURE_PMP);
+ }
+ 
++static void rv32imafcu_nommu_cpu_init(Object *obj)
++{
++    CPURISCVState *env = &RISCV_CPU(obj)->env;
++    set_misa(env, RV32 | RVI | RVM | RVA | RVF | RVC | RVU);
++    set_priv_version(env, PRIV_VERSION_1_10_0);
++    set_resetvec(env, DEFAULT_RSTVEC);
++    set_feature(env, RISCV_FEATURE_PMP);
++}
++
+ #elif defined(TARGET_RISCV64)
+ 
+ static void riscv_base64_cpu_init(Object *obj)
+@@ -609,6 +618,7 @@ static const TypeInfo riscv_cpu_type_infos[] = {
+ #if defined(TARGET_RISCV32)
+     DEFINE_CPU(TYPE_RISCV_CPU_BASE32,           riscv_base32_cpu_init),
+     DEFINE_CPU(TYPE_RISCV_CPU_SIFIVE_E31,       rv32imacu_nommu_cpu_init),
++    DEFINE_CPU(TYPE_RISCV_CPU_SIFIVE_E34,       rv32imafcu_nommu_cpu_init),
+     DEFINE_CPU(TYPE_RISCV_CPU_SIFIVE_U34,       rv32gcsu_priv1_10_0_cpu_init),
+     /* Depreacted */
+     DEFINE_CPU(TYPE_RISCV_CPU_RV32IMACU_NOMMU,  rv32imacu_nommu_cpu_init),
+diff --git a/target/riscv/cpu.h b/target/riscv/cpu.h
+index 3dcdf92227..ae5a1d9dce 100644
+--- a/target/riscv/cpu.h
++++ b/target/riscv/cpu.h
+@@ -36,6 +36,7 @@
+ #define TYPE_RISCV_CPU_BASE32           RISCV_CPU_TYPE_NAME("rv32")
+ #define TYPE_RISCV_CPU_BASE64           RISCV_CPU_TYPE_NAME("rv64")
+ #define TYPE_RISCV_CPU_SIFIVE_E31       RISCV_CPU_TYPE_NAME("sifive-e31")
++#define TYPE_RISCV_CPU_SIFIVE_E34       RISCV_CPU_TYPE_NAME("sifive-e34")
+ #define TYPE_RISCV_CPU_SIFIVE_E51       RISCV_CPU_TYPE_NAME("sifive-e51")
+ #define TYPE_RISCV_CPU_SIFIVE_U34       RISCV_CPU_TYPE_NAME("sifive-u34")
+ #define TYPE_RISCV_CPU_SIFIVE_U54       RISCV_CPU_TYPE_NAME("sifive-u54")
+-- 
+2.21.1
+

--- a/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
@@ -13,6 +13,8 @@ SRC_URI = "git://github.com/qemu/qemu.git;protocol=https \
 	   file://0002-hw-sparc-leon-Fix-compilation-errors.patch \
 	   file://0003-hw-sparc-leon-timer-Call-leon_timer_io_read-for-TIME.patch \
 	   file://0004-hw-sparc-leon-Switch-to-transaction-based-ptimer-API.patch \
+	   file://0005-riscv-sifive_e-Support-changing-CPU-type.patch \
+	   file://0006-target-riscv-Add-a-sifive-e34-cpu-type.patch \
 "
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
This change allows the sifive_e machine to run with different CPU
targets to enable different ISA entensions. To that end it also
introduces a new sifive-e34 CPU type which provides the same ISA
as sifive-e31, with the addition of the single precision
floating-point extension (f). The default CPU for the sifive_e
machine is unchanged.

Signed-off-by: Corey Wharton <coreyw7@fb.com>