### PR TITLE
SPARC: fix issue with timer in QEMU machine AT697

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0004-hw-sparc-leon-Switch-to-transaction-based-ptimer-API.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0004-hw-sparc-leon-Switch-to-transaction-based-ptimer-API.patch
@@ -60,11 +60,11 @@ index 8e38a33c62..f2e12d714f 100644
      case TIMER_1_COUNTER_REGISTER:
 +        ptimer_transaction_begin(s->timer1.ptimer);
          ret = ptimer_get_count(s->timer1.ptimer);
-+        ptimer_transaction_commit(s->timer2.ptimer);
++        ptimer_transaction_commit(s->timer1.ptimer);
          break;
  
      case TIMER_2_COUNTER_REGISTER:
-+        ptimer_transaction_begin(s->timer1.ptimer);
++        ptimer_transaction_begin(s->timer2.ptimer);
          ret = ptimer_get_count(s->timer2.ptimer);
 +        ptimer_transaction_commit(s->timer2.ptimer);
          break;


### PR DESCRIPTION
Fixes following bug:
`sdk-zephyr-qemu/git-r0/git/hw/core/ptimer.c:384: ptimer_transaction_commit: Assertion `s->in_transaction' failed.`

I'm not sure if it's okay to just edit existing patch, or to add another, but editing existing patch for now.