### PR TITLE
Fix use of CRC32 intrinsics with Armv8-a and hard-float

### DIFF
--- a/patches/gcc/9.2.0/0001-arm-Fix-use-of-CRC32-intrinsics-with-Armv8-a-and-har.patch
+++ b/patches/gcc/9.2.0/0001-arm-Fix-use-of-CRC32-intrinsics-with-Armv8-a-and-har.patch
@@ -1,0 +1,50 @@
+From 28e0d7f15c5aa1fabd0b4b23d88d88263363cce9 Mon Sep 17 00:00:00 2001
+From: Kyrylo Tkachov <kyrylo.tkachov@arm.com>
+Date: Wed, 25 Sep 2019 13:48:29 +0000
+Subject: [PATCH] [arm] Fix use of CRC32 intrinsics with Armv8-a and hard-float
+
+	Backport from mainline
+	2019-08-22  Kyrylo Tkachov <kyrylo.tkachov@arm.com>
+
+	* config/arm/arm_acle.h: Use arch=armv8-a+crc+simd pragma for CRC32
+	intrinsics if __ARM_FP.
+	Use __ARM_FEATURE_CRC32 ifdef guard.
+
+	* gcc.target/arm/acle/crc_hf_1.c: New test.
+
+From-SVN: r276126
+---
+ gcc/ChangeLog                                |  9 +++++++++
+ gcc/config/arm/arm_acle.h                    |  8 ++++++--
+ gcc/testsuite/ChangeLog                      |  7 +++++++
+ gcc/testsuite/gcc.target/arm/acle/crc_hf_1.c | 14 ++++++++++++++
+ 4 files changed, 36 insertions(+), 2 deletions(-)
+ create mode 100644 gcc/testsuite/gcc.target/arm/acle/crc_hf_1.c
+
+diff --git a/gcc/config/arm/arm_acle.h b/gcc/config/arm/arm_acle.h
+index 2c7acc698ea..6857ab1787d 100644
+--- a/gcc/config/arm/arm_acle.h
++++ b/gcc/config/arm/arm_acle.h
+@@ -174,8 +174,12 @@ __arm_mrrc2 (const unsigned int __coproc, const unsigned int __opc1,
+ #endif /* (!__thumb__ || __thumb2__) &&  __ARM_ARCH >= 4.  */
+ 
+ #pragma GCC push_options
+-#if __ARM_ARCH >= 8
++#ifdef __ARM_FEATURE_CRC32
++#ifdef __ARM_FP
++#pragma GCC target ("arch=armv8-a+crc+simd")
++#else
+ #pragma GCC target ("arch=armv8-a+crc")
++#endif
+ 
+ __extension__ static __inline uint32_t __attribute__ ((__always_inline__))
+ __crc32b (uint32_t __a, uint8_t __b)
+@@ -235,7 +239,7 @@ __crc32cd (uint32_t __a, uint64_t __b)
+ }
+ #endif
+ 
+-#endif /* __ARM_ARCH >= 8.  */
++#endif /* __ARM_FEATURE_CRC32  */
+ #pragma GCC pop_options
+ 
+ #ifdef __cplusplus


### PR DESCRIPTION
Backport patch from gcc to fix issue with building w/arm_acle.h.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>