### PR TITLE
[TEST] ci: Add GitHub Actions support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+        - nios2
+       #- arm # Too much disk usage
+        - arm64
+        - riscv64
+        - arc
+        - sparc
+        - x86_64-zephyr-elf
+        - xtensa_sample_controller
+        - xtensa_intel_apl_adsp
+        - xtensa_intel_bdw_adsp
+        - xtensa_intel_byt_adsp
+        - xtensa_intel_s1000
+        - xtensa_nxp_imx_adsp
+        - xtensa_nxp_imx8m_adsp
+
+    steps:
+    # Set up build environment
+    - name: Install dependency packages
+      run: |
+        sudo apt-get install bison flex gettext help2man libncurses5-dev
+        sudo apt-get install libtool-bin libtool-doc texinfo
+        sudo apt-get install python3.8-dev
+
+    # Check out source code
+    - name: Check out source code
+      uses: actions/checkout@v2
+
+    # Build 
+    - name: Build
+      run: |
+        ./go.sh ${{ matrix.target }}


### PR DESCRIPTION
Just assessing the feasibility of migrating the CI cross toolchain builds to the GitHub Actions.

The ARM cross toolchain build is known to fail because it builds many multilibs and the GitHub-provided machines only include 14GB of SSD space.