### PR TITLE
ci: Add initial buildkite support

### DIFF
--- a/.buildkite/deploy.yml
+++ b/.buildkite/deploy.yml
@@ -1,0 +1,35 @@
+steps:
+  - command:
+      - sudo apt-get install -y makeself p7zip-full cpio tree curl
+      - sudo pip3 install setuptools
+      - sudo pip3 install awscli
+      - >
+        if [ "${BUILDKITE_PULL_REQUEST}" != "false" ]; then
+           sed -i "s/$$/-pr-${BUILDKITE_PULL_REQUEST}/" VERSION;
+        fi
+      - release=$(cat VERSION)
+      - echo "Release - [$${release}] $${release}"
+
+      - >
+        if [ -n "${BUILDKITE_TAG}" ]; then
+           if [ "${BUILDKITE_TAG}" != $${release} ]; then
+              echo "Need to fix VERSION file.  Tag ${BUILDKITE_TAG} doesn't match $${release}"
+              #exit 1
+           fi
+           export S3_PUB_PATH="s3://builds.zephyrproject.org/sdk/${BUILDKITE_TAG}/"
+        elif [ "${BUILDKITE_PULL_REQUEST}" != "false" ]; then
+           export S3_PUB_PATH="s3://builds.zephyrproject.org/zephyrproject-rtos/sdk-ng/${BUILDKITE_PULL_REQUEST}/"        
+        fi
+      - echo "S3_PUB_PATH - [$${S3_PUB_PATH}]"
+      - mkdir -p scripts/toolchains
+      - cd scripts/toolchains
+      - buildkite-agent artifact download *.tar.bz2 . --build $${BUILDKITE_TRIGGERED_FROM_BUILD_ID}
+      - buildkite-agent artifact download *.sh . --build $${BUILDKITE_TRIGGERED_FROM_BUILD_ID}
+      - chmod a+x *.sh     
+      - cd ..
+      - tree -H '.' -L 1 --noreport --charset utf-8 toolchains > index.html
+      - ./make_zephyr_sdk.sh
+      - ls -F
+      - sdk_filename=$(ls -1 zephyr-sdk*)
+      - toolchain_files=$(ls -1 zephyr-toolchain-*)
+      - hosttools_filename=$(ls -1 toolchains/*hosttools*)

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright (c) 2020 Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Save off where we started so we can go back there
+WORKDIR=${PWD}
+
+ls -lsa .git
+
+if [ -n "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}" ]; then
+   git fetch -v origin ${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
+   git checkout FETCH_HEAD
+   git config --local user.email "builds@zephyrproject.org"
+   git config --local user.name "Zephyr CI"
+   git merge --no-edit "${BUILDKITE_COMMIT}" || {
+       local merge_result=$?
+       echo "Merge failed: ${merge_result}"
+       git merge --abort
+       exit $merge_result
+   }
+   ls -lsa .git
+fi
+
+mkdir -p /var/lib/buildkite-agent/zephyr-ccache/
+
+# create cache dirs, no-op if they already exist
+mkdir -p /var/lib/buildkite-agent/zephyr-module-cache/modules
+mkdir -p /var/lib/buildkite-agent/zephyr-module-cache/tools
+mkdir -p /var/lib/buildkite-agent/zephyr-module-cache/bootloader
+
+# Clean cache - if it already exists
+cd /var/lib/buildkite-agent/zephyr-module-cache
+find -type f -not -path "*/.git/*" -not -name ".git" -delete
+
+# Remove any stale locks
+find -name index.lock -delete
+
+# return from where we started so we can find pipeline files from
+# git repo
+cd ${WORKDIR}

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,56 @@
+steps:
+  - command:
+    - >
+      case "$${BUILDKITE_PARALLEL_JOB}" in
+         0)  TARGET="arm";;
+         1)  TARGET="arc";;
+         2)  TARGET="tools";;
+         3)  TARGET="riscv64";;
+         4)  TARGET="nios2";;
+         5)  TARGET="sparc";;
+         6)  TARGET="x86_64-zephyr-elf";;
+         7)  TARGET="arm64";;
+         8)  TARGET="xtensa_sample_controller";;
+         9)  TARGET="xtensa_intel_apl_adsp";;
+         10) TARGET="xtensa_intel_bdw_adsp";;
+         11) TARGET="xtensa_intel_byt_adsp";;
+         12) TARGET="xtensa_nxp_imx_adsp";;
+         13) TARGET="xtensa_nxp_imx8m_adsp";;
+         14) TARGET="xtensa_intel_s1000";;
+         15) TARGET="cmake";;
+      esac
+    - >
+      if [ $${TARGET} = "tools" ]; then
+         touch zephyr-sdk-x86_64-hosttools-standalone-0.9.sh;
+         buildkite-agent artifact upload zephyr-sdk-x86_64-hosttools-standalone-0.9.sh;
+      elif [ $${TARGET} = "cmake" ]; then
+         touch cmake.tar.bz2;
+         buildkite-agent artifact upload cmake.tar.bz2;
+      else
+         touch $${TARGET}.tar.bz2;
+         buildkite-agent artifact upload $${TARGET}.tar.bz2;         
+      fi
+    parallelism: 16
+    env:
+      BUILDKITE_CLEAN_CHECKOUT: "true"
+    plugins:
+      - docker#v3.5.0:
+          image: "zephyrprojectrtos/sdk-build"
+          propagate-environment: true
+          user: buildkite-agent
+    agents:
+    - "queue=sdk-ng-x86"
+
+  - wait
+
+  - trigger: "sdk-deploy"
+    if: build.tag != null || build.pull_request.id != null
+    build:
+      message: "${BUILDKITE_MESSAGE}"
+      commit: "${BUILDKITE_COMMIT}"
+      branch: "${BUILDKITE_BRANCH}"
+      env:
+        BUILDKITE_PULL_REQUEST: "${BUILDKITE_PULL_REQUEST}"
+        BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
+        BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
+        BUILDKITE_TAG: "${BUILDKITE_TAG}"


### PR DESCRIPTION
Add buildkite related CI files.  We add the starts of a deploy.yml that
will not directly get invoked by buildkite for security reasons.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>