### PR TITLE
x86_64: newlib: use march=pentium for 32-bit

### DIFF
--- a/patches/newlib/3.1.0.20181231/0003-Support-building-for-32-bit-under-x86_64.patch
+++ b/patches/newlib/3.1.0.20181231/0003-Support-building-for-32-bit-under-x86_64.patch
@@ -1,4 +1,4 @@
-From dc48595340a292f044a0fddcab2d67a81650010f Mon Sep 17 00:00:00 2001
+From 7fa9f8eb8aff8bd73d04dd04f72eeac4682e38dc Mon Sep 17 00:00:00 2001
 From: Daniel Leung <daniel.leung@intel.com>
 Date: Wed, 8 May 2019 09:17:10 -0700
 Subject: [PATCH 3/3] Support building for 32-bit under x86_64
@@ -10,14 +10,14 @@ x86_64.
 Signed-off-by: Daniel Leung <daniel.leung@intel.com>
 Signed-off-by: Kumar Gala <kumar.gala@linaro.org>
 ---
- newlib/configure.host | 14 +++++++++++++-
- 1 file changed, 13 insertions(+), 1 deletion(-)
+ newlib/configure.host | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
 
 diff --git a/newlib/configure.host b/newlib/configure.host
-index 6c49cb750..37d2b9b2e 100644
+index 6c49cb7..d739dda 100644
 --- a/newlib/configure.host
 +++ b/newlib/configure.host
-@@ -333,7 +333,19 @@ case "${host_cpu}" in
+@@ -333,7 +333,20 @@ case "${host_cpu}" in
  	machine_dir=w65
  	;;
    x86_64)
@@ -27,6 +27,7 @@ index 6c49cb750..37d2b9b2e 100644
 +	      libm_machine_dir=i386
 +	      machine_dir=i386
 +	      mach_add_setjmp=true
++	      newlib_cflags="${newlib_cflags} -march=pentium"
 +	      ;;
 +	  *-mx32)
 +	      machine_dir=x86_64
@@ -39,5 +40,5 @@ index 6c49cb750..37d2b9b2e 100644
    xc16x*)
          machine_dir=xc16x
 -- 
-2.24.1
+2.27.0
 


### PR DESCRIPTION
The 32-bit build on Zephyr main tree is targeting Pentium-based
devices. However, given the target tuple, newlib is being built
targeting i686 by default. This emits instructions that cannot
run on Pentium-based devices. So add a march=pentium when
newlib is being built for x86_64 32-bit.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>