### PR TITLE
qemu: Add icount for ARC

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0007-ARC-Fix-icount-support.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0007-ARC-Fix-icount-support.patch
@@ -1,0 +1,57 @@
+From 45e7fc2ce84609a96960666f49674b9700a1737f Mon Sep 17 00:00:00 2001
+From: Alexey Brodkin <abrodkin@synopsys.com>
+Date: Sat, 4 Jul 2020 00:52:00 +0300
+Subject: [PATCH] ARC: Fix icount support
+
+Looks like we have everything in place for using icount except
+we don't take care about I/O.
+
+Given writes to AUX register:
+ a) May lead to IRQ (if we change ARC Timer LIMIT or COUNT regs)
+ b) Via ARc Timers interact with host's time
+ b) Anyways are often used to access some kind of peripherals or even
+    specific ARC internals which might be treated as I/O
+
+Let's mark TB's where we execute LR/SR instructions as possible I/O.
+
+Signed-off-by: Alexey Brodkin <abrodkin@synopsys.com>
+---
+ target/arc/arc-semfunc.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/target/arc/arc-semfunc.c b/target/arc/arc-semfunc.c
+index b6cd48ce56..e5d0b86004 100644
+--- a/target/arc/arc-semfunc.c
++++ b/target/arc/arc-semfunc.c
+@@ -4069,6 +4069,7 @@ arc2_gen_AEX (DisasCtxt *ctx, TCGv src2, TCGv b)
+ 
+ 
+ 
++#include "exec/gen-icount.h"
+ 
+ 
+ /* LR
+@@ -4084,6 +4085,10 @@ int
+ arc2_gen_LR (DisasCtxt *ctx, TCGv dest, TCGv src)
+ {
+   int ret = DISAS_NEXT;
++
++  if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT)
++    gen_io_start();
++
+   TCGv temp_1 = tcg_temp_local_new_i32();
+   readAuxReg(temp_1, src);
+   tcg_gen_mov_i32(dest, temp_1);
+@@ -4110,6 +4115,9 @@ arc2_gen_SR (DisasCtxt *ctx, TCGv src2, TCGv src1)
+ {
+   int ret = DISAS_NEXT;
+ 
++  if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT)
++    gen_io_start();
++
+   writeAuxReg(src2, src1);
+   return ret;
+ }
+-- 
+2.16.2
+

--- a/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
@@ -16,6 +16,7 @@ SRC_URI = "git://github.com/qemu/qemu.git;protocol=https \
 	   file://0005-riscv-sifive_e-Support-changing-CPU-type.patch \
 	   file://0006-target-riscv-Add-a-sifive-e34-cpu-type.patch \
            file://0006-Add-support-for-ARCv2-architecture.patch \
+	   file://0007-ARC-Fix-icount-support.patch \
 "
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
This adds `icount` support for ARC needed for https://github.com/zephyrproject-rtos/zephyr/pull/26646.