### PR TITLE
qemu: Fix search path breakage in qemu 5.0.0.

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0008-os_find_datadir-search-as-in-version-4.2.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0008-os_find_datadir-search-as-in-version-4.2.patch
@@ -1,0 +1,43 @@
+From 34e8bfc991aa38b66290326b7bf6a8eab5164cd1 Mon Sep 17 00:00:00 2001
+From: Joe Slater <joe.slater@windriver.com>
+Date: Mon, 15 Jun 2020 15:58:27 -0700
+Subject: [PATCH] os_find_datadir: search as in version 4.2
+
+Always look for ../share/qemu then ../pc-bios when looking for datadir.
+
+Signed-off-by: Joe Slater <joe.slater@windriver.com>
+---
+ os-posix.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/os-posix.c b/os-posix.c
+index 3cd52e1e70..f77da94bf6 100644
+--- a/os-posix.c
++++ b/os-posix.c
+@@ -82,8 +82,9 @@ void os_setup_signal_handling(void)
+ 
+ /*
+  * Find a likely location for support files using the location of the binary.
++ * Typically, this would be "$bindir/../share/qemu".
+  * When running from the build tree this will be "$bindir/../pc-bios".
+- * Otherwise, this is CONFIG_QEMU_DATADIR.
++ * Otherwise, this is CONFIG_QEMU_DATADIR as constructed by configure.
+  */
+ char *os_find_datadir(void)
+ {
+@@ -93,6 +94,12 @@ char *os_find_datadir(void)
+     exec_dir = qemu_get_exec_dir();
+     g_return_val_if_fail(exec_dir != NULL, NULL);
+ 
++    dir = g_build_filename(exec_dir, "..", "share", "qemu", NULL);
++    if (g_file_test(dir, G_FILE_TEST_IS_DIR)) {
++        return g_steal_pointer(&dir);
++    }
++    g_free(dir);  /* no autofree this time */
++
+     dir = g_build_filename(exec_dir, "..", "pc-bios", NULL);
+     if (g_file_test(dir, G_FILE_TEST_IS_DIR)) {
+         return g_steal_pointer(&dir);
+-- 
+2.25.4
+

--- a/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
@@ -17,6 +17,7 @@ SRC_URI = "git://github.com/qemu/qemu.git;protocol=https \
 	   file://0006-target-riscv-Add-a-sifive-e34-cpu-type.patch \
            file://0006-Add-support-for-ARCv2-architecture.patch \
 	   file://0007-ARC-Fix-icount-support.patch \
+	   file://0008-os_find_datadir-search-as-in-version-4.2.patch \
 "
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
If we move the install of qemu from how --prefix is set we run into
issues trying to find bios files.  This is because searching in
share/qemu relative to the executable was removed in qemu 5.0.0.  Pull
in a patch from the qemu-devel mail list that restores searching in
share/qemu.

Fixes #242

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>