### PR TITLE
make_zephyr_sdk: Rename toolchain packages to include arch & OS

### DIFF
--- a/scripts/make_zephyr_sdk.sh
+++ b/scripts/make_zephyr_sdk.sh
@@ -15,11 +15,12 @@ product_name="zephyr-sdk"
 
 root_dir=$(dirname $0)/..
 sdk_version=$(cat $root_dir/VERSION)
+machine=$(uname -m)
 arch_list="arm arm64 arc nios2 riscv64 sparc x86_64 xtensa_sample_controller \
            xtensa_intel_apl_adsp xtensa_intel_s1000 xtensa_intel_bdw_adsp \
 	   xtensa_intel_byt_adsp xtensa_nxp_imx_adsp xtensa_nxp_imx8m_adsp"
 
-echo "Creating ${product_name}-${sdk_version}-setup.run"
+echo "Creating ${product_name}-${sdk_version}-${machine}-linux-setup.run"
 
 # Create ./setup.sh
 
@@ -137,7 +138,7 @@ create_toolchain()
 {
 	local arch=$1
 	local setup=toolchains/${arch}/setup.sh
-	local toolchain_name=zephyr-toolchain-${arch}-${sdk_version}-setup.run
+	local toolchain_name=zephyr-toolchain-${arch}-${sdk_version}-${machine}-linux-setup.run
 
 	var_file_arch=file_gcc_${arch}
 	file_gcc_arch=${!var_file_arch}
@@ -168,7 +169,7 @@ create_toolchain()
 create_sdk()
 {
 	local setup=toolchains/setup.sh
-	local toolchain_name=${product_name}-${sdk_version}-setup.run
+	local toolchain_name=${product_name}-${sdk_version}-${machine}-linux-setup.run
 
 	setup_hdr $setup $toolchain_name
 	for arch in $arch_list; do


### PR DESCRIPTION
Rename toolchain packages to include ${machine} and linux in the name to
handle both support for x86-64 & aarch64 (arm64) linux builds as well as
in the future possibly having Win and MacOS X builds.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>