### PR TITLE
scripts/template_dir (setup.sh): fixes for unattended setup for distro packagers

### DIFF
--- a/scripts/template_dir
+++ b/scripts/template_dir
@@ -66,7 +66,9 @@ while [ "$1" != "" ]; do
 			;;
 		-y )
 			confirm="y";
-			rc_confirm="y";
+			if [ -z "$rc_confirm" ]; then
+			  rc_confirm="y"
+			fi
 			;;
 		-rc )
 			rc_confirm="y";

--- a/scripts/template_dir
+++ b/scripts/template_dir
@@ -144,7 +144,7 @@ do_zephyrrc()
 	echo "     export ZEPHYR_SDK_INSTALL_DIR=$target_sdk_dir"
 	echo
 	if [ -z "$rc_confirm" ]; then
-		prompt "creating/updating $HOME/.zephyrrc with environment variables setup for you "
+		prompt "create/update $HOME/.zephyrrc with environment variables setup for you "
 		rc_confirm=$answer
 	fi
 	if [ "$rc_confirm" = "y" ]; then
@@ -172,7 +172,7 @@ do_cmake_package()
 		fi
 
 		if [ -z "$cmake_confirm" ]; then
-			prompt "registering Zephyr-sdk CMake module with path $target_sdk_dir "
+			prompt "register Zephyr-sdk CMake module with path $target_sdk_dir "
 			cmake_confirm=$answer
 		fi
 		if [ "$cmake_confirm" = "y" ]; then
@@ -188,7 +188,7 @@ do_cmake_package()
 # Read the input "y"
 # $1 is optional, but allows the caller to provide additional text.
 prompt () {
-	echo "Do you want to continue $1(y/n)? "
+	echo "Do you want to $1(y/n)? "
 	while read answer; do
 		if [ "$answer" = "Y" -o "$answer" = "y" ]; then
 			answer="y"

--- a/scripts/template_dir
+++ b/scripts/template_dir
@@ -163,15 +163,7 @@ do_cmake_package()
 			return
 		fi
 
-		echo "Do you want to register the Zephyr-sdk at location: $target_sdk_dir"
-		echo "  in the CMake package registry (y/n)?"
-
-		while read confirm; do
-			[ "$confirm" = "Y" -o "$confirm" = "y" -o "$confirm" = "n" \
-			-o "$confirm" = "N" ] && break
-			echo "Invalid input \"$confirm\", please input 'y' or 'n': "
-		done
-
+		read_confirm "registering Zephyr-sdk CMake module with path $target_sdk_dir "
 		if [ "$confirm" = "y" -o "$confirm" = "Y" ]; then
 			if [ ! -d $ZEPHYR_SDK_REGISTRY_DIR ]; then
 				mkdir -p $ZEPHYR_SDK_REGISTRY_DIR

--- a/scripts/template_dir
+++ b/scripts/template_dir
@@ -3,6 +3,7 @@ target_sdk_dir=""
 post_install_cleanup=1
 confirm=0
 rc_confirm=""
+cmake_confirm=""
 
 usage () {
   cat << EOF
@@ -21,6 +22,9 @@ Options:
 
   -[no]rc
         Whether to create/update the ~/.zerphyrc file (prompt if not given)
+
+  -[no]cmake
+        Whether to install Zephyr-sdk CMake module (prompt if not given)
 
 EOF
 }
@@ -69,12 +73,21 @@ while [ "$1" != "" ]; do
 			if [ -z "$rc_confirm" ]; then
 			  rc_confirm="y"
 			fi
+			if [ -z "$cmake_confirm" ]; then
+			  cmake_confirm="y"
+			fi
 			;;
 		-rc )
 			rc_confirm="y";
 			;;
 		-norc )
 			rc_confirm="n";
+			;;
+		-cmake )
+			cmake_confirm="y"
+			;;
+		-nocmake )
+			cmake_confirm="n"
 			;;
 		* )
 			echo "Error: Invalid argument \"$1\""
@@ -158,8 +171,11 @@ do_cmake_package()
 			return
 		fi
 
-		query "registering Zephyr-sdk CMake module with path $target_sdk_dir "
-		if [ "$answer" = "y" ]; then
+		if [ -z "$cmake_confirm" ]; then
+			prompt "registering Zephyr-sdk CMake module with path $target_sdk_dir "
+			cmake_confirm=$answer
+		fi
+		if [ "$cmake_confirm" = "y" ]; then
 			if [ ! -d $ZEPHYR_SDK_REGISTRY_DIR ]; then
 				mkdir -p $ZEPHYR_SDK_REGISTRY_DIR
 			fi

--- a/scripts/template_dir
+++ b/scripts/template_dir
@@ -131,15 +131,10 @@ do_zephyrrc()
 	echo "     export ZEPHYR_SDK_INSTALL_DIR=$target_sdk_dir"
 	echo
 	if [ -z "$rc_confirm" ]; then
-		echo "Update/Create $HOME/.zephyrrc with environment variables setup for you (y/n)? "
-		while read rc_confirm; do
-			[ "$rc_confirm" = "Y" -o "$rc_confirm" = "y" \
-			-o "$rc_confirm" = "n" \
-			-o "$rc_confirm" = "N" ] && break
-			echo "Invalid input \"$rc_confirm\", please input 'y' or 'n': "
-		done
+		prompt "creating/updating $HOME/.zephyrrc with environment variables setup for you "
+		rc_confirm=$answer
 	fi
-	if [ "$rc_confirm" = "y" -o "$rc_confirm" = "Y" ]; then
+	if [ "$rc_confirm" = "y" ]; then
 		if [ -f $HOME/.zephyrrc ]; then
 			sed -i "s#ZEPHYR_SDK_INSTALL_DIR=.*#ZEPHYR_SDK_INSTALL_DIR=${target_sdk_dir}#" $HOME/.zephyrrc
 			sed -i "s#ZEPHYR_TOOLCHAIN_VARIANT=.*#ZEPHYR_TOOLCHAIN_VARIANT=zephyr#" $HOME/.zephyrrc
@@ -163,8 +158,8 @@ do_cmake_package()
 			return
 		fi
 
-		read_confirm "registering Zephyr-sdk CMake module with path $target_sdk_dir "
-		if [ "$confirm" = "y" -o "$confirm" = "Y" ]; then
+		query "registering Zephyr-sdk CMake module with path $target_sdk_dir "
+		if [ "$answer" = "y" ]; then
 			if [ ! -d $ZEPHYR_SDK_REGISTRY_DIR ]; then
 				mkdir -p $ZEPHYR_SDK_REGISTRY_DIR
 			fi
@@ -176,17 +171,28 @@ do_cmake_package()
 
 # Read the input "y"
 # $1 is optional, but allows the caller to provide additional text.
-read_confirm () {
-  if [ "$confirm" != "y" ]; then
-      echo "Do you want to continue $1(y/n)? "
-      while read confirm; do
-          [ "$confirm" = "Y" -o "$confirm" = "y" -o "$confirm" = "n" \
-            -o "$confirm" = "N" ] && break
-          echo "Invalid input \"$confirm\", please input 'y' or 'n': "
-      done
-  else
-      echo
-  fi
+prompt () {
+	echo "Do you want to continue $1(y/n)? "
+	while read answer; do
+		if [ "$answer" = "Y" -o "$answer" = "y" ]; then
+			answer="y"
+			break
+		elif [ "$answer" = "N" -o "$answer" = "n" ]; then
+			answer="n"
+			break
+		else
+			echo "Invalid input \"$answer\", please input 'y' or 'n': "
+		fi
+	done
+}
+# Like prompt, but only if prompts were not pre-answered by -y argument
+query () {
+	if [ "$confirm" != "y" ]; then
+		prompt "$1"
+	else
+		answer="y"
+		echo
+	fi
 }
 
 verify_os
@@ -261,8 +267,8 @@ if [    "$sdk_dirname" != "/opt" \
 	echo Note: The version number \'-$SDK_VERSION\' can be omitted.
 	echo
 
-	read_confirm "installing to ${target_sdk_dir} "
-	if [ "$confirm" = "n" -o "$confirm" = "N" ]; then
+	query "installing to ${target_sdk_dir} "
+	if [ "$answer" = "n" ]; then
 		# Abort the installation
 		echo "SDK installation aborted!"
 		exit 1
@@ -282,8 +288,8 @@ if [ -d $target_sdk_dir ]; then
 		# wipe the directory first
 		if [ -d $target_sdk_dir/sysroots ]; then
 			echo "The directory $target_sdk_dir/sysroots will be removed! "
-			read_confirm
-			if [ "$confirm" = "y" -o "$confirm" = "Y" ]; then
+			query
+			if [ "$answer" = "y" ]; then
 		        	rm -rf $target_sdk_dir/sysroots/
 				rm -rf $target_sdk_dir/info-zephyr-sdk*/
 				rm -fr $target_sdk_dir/sdk_version


### PR DESCRIPTION
Fixes a few issues encountered when scripting the installation for distro package:
1. Issue introduced when cmake module was added: the user was prompted even if -y was passed, which broke unattended installation.
2. CMake module installed under $HOME unconditionally, and the path to SDK in the cmake module equals destination directory, which is not necessarily the same as the final installation path in the system (details below). This issue is not solved, but only worked around by adding -[no]cmake args so that the problematic cmake module generation can be disabled and performed out-of-band by the packager script. 
3. Order of -y and -[no]rc  arguments mattered due to -y unintentionally overriding -[no]rc. Overlooked in 6dd3e26c271bbf139f6d30523bc55fc7673b52f5.
4. Duplication of code for prompting user

Tested these patches applied on top of 0.11.4 release, did not test in master.

Suggesting to review one commit at a time and also suggest not to squash the commits when merging:
 
```
commit 706b10cddfd781e3c7f1006a64ad23e09601e77c
    scripts/template_dir: -[no]cmake flag for CMake module installation
    
    There are two issues with CMake module installation that are
    problematic for distro packages:
    1. the cmake module is installed under $HOME and this path is not overridable
    2. the path to SDK recorded in the cmake file is the same as the
    target directory, which might be prefixed by the staging path of the
    package build (e.g.  ~/mypackages/zerphyr-sdk/destdir/opt/zerphyr-sdk),
    not the final installation directory in the system (/opt/zephyr-sdk).
    
    1 is fixable by making the variable overridable from the environment:
        : ${ZEPHYR_SDK_REGISTRY_DIR:=$HOME/.cmake/packages/Zephyr-sdk}
    (but this may be a bashism). But, 1 is not useful unless 2 is also
    addressed.
    
    2 might be fixable by introducing a prefix argument -p (default "") in
    addition to the target_dir (-d), and composing the destination directory
    for copying files as $prefix/$target_dir while using only $target_dir
    wherever installation paths are written, such as in the CMake module.
    
    Until 1 or 2 are addressed, add -[no]cmake arg so that the package
    scripts can install the CMake module themselves.

commit 03933375277558f939a12990cae3ee372511d87e
    scripts/template_dir: re-use common prompting code

commit e2e27bb5c5c044203c6085279a99514416799c51
    scripts/template_dir: don't prompt for cmake when -y set

commit b8d47d156f3e89237a80b349eb2ec48160046b05
    scripts/template_dir: don't let -y override -[no]rc
```
