### PR TITLE
cmake: Set HOST_TOOLS_HOME based on OS_PLATFORM

### DIFF
--- a/cmake/zephyr/host-tools.cmake
+++ b/cmake/zephyr/host-tools.cmake
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(HOST_TOOLS_HOME ${ZEPHYR_SDK_INSTALL_DIR}/sysroots/x86_64-pokysdk-linux)
+cmake_host_system_information(RESULT TOOLCHAIN_ARCH QUERY OS_PLATFORM)
+set(HOST_TOOLS_HOME ${ZEPHYR_SDK_INSTALL_DIR}/sysroots/${TOOLCHAIN_ARCH}-pokysdk-linux)
 
 # Path used for searching by the find_*() functions, with appropriate
 # suffixes added. Ensures that the SDK's host tools will be found when


### PR DESCRIPTION
To support both x86_64 and aarch64 host env we need to set
HOST_TOOLS_HOME correct and we utilize OS_PLATFORM from
cmake_host_system_information to do that (which on linux will be the
result of `uname -m`).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>