### PR TITLE
openocd: bump to new upstream based openocd

### DIFF
--- a/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_0.10.0.bb
+++ b/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_0.10.0.bb
@@ -9,7 +9,7 @@ RDEPENDS_${PN} = "libusb1 hidapi"
 SRC_URI = " \
 	git://github.com/zephyrproject-rtos/openocd.git;protocol=https;nobranch=1 \
 	"
-SRCREV = "580d06d9dd8267cd88a62305996908d5eaf4b04c"
+SRCREV = "d55ab23543bde5833338d080e512276918ae23a4"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Bump SHA to point to openocd based on upstream SHA:
fa9a4d4db5cfe44b7aadb1b8ef220f94423742a1

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>