### PR TITLE
crosstool-ng: Update to newer upstream for centos build fix

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -12,7 +12,7 @@ if [ "$TARGETS" == "all" ]; then
 	TARGETS=${TARGETS}" tools"
 fi
 
-COMMIT="b7cd9816e9eeb1adbd60904affbee6b1fe65b9b6"
+COMMIT="9551914180907903a3ede4cdfc1c62af96f15010"
 GITDIR=${PWD}
 JOBS=$(python -c 'import multiprocessing as mp; print(mp.cpu_count())')
 


### PR DESCRIPTION
Pull in fix for compat on centOS.  See commit in upstream crosstool-ng:

commit 57f59092852dff18fbda68fdbf23f850ad182c40
Author: Alexey Brodkin <abrodkin@synopsys.com>
Date:   Wed Oct 14 22:35:03 2020 +0300

    binutils: Disable glob for better portability

Fixes: #280

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>