### PR TITLE
cmake: Add SPARC support

### DIFF
--- a/cmake/zephyr/target.cmake
+++ b/cmake/zephyr/target.cmake
@@ -11,6 +11,7 @@ set(CROSS_COMPILE_TARGET_mips     mipsel-zephyr-elf)
 set(CROSS_COMPILE_TARGET_xtensa   xtensa-zephyr-elf)
 set(CROSS_COMPILE_TARGET_arc         arc-zephyr-elf)
 set(CROSS_COMPILE_TARGET_x86      x86_64-zephyr-elf)
+set(CROSS_COMPILE_TARGET_sparc     sparc-zephyr-elf)
 
 set(CROSS_COMPILE_TARGET ${CROSS_COMPILE_TARGET_${ARCH}})
 set(SYSROOT_TARGET       ${CROSS_COMPILE_TARGET})


### PR DESCRIPTION
Define sparc-zephyr-elf as tool prefix when ARCH=sparc. This allows
cmake to generate the SDK-NG SPARC toolchain path.
