### PR TITLE
gcc: update multilibs for SPARC

### DIFF
--- a/patches/gcc/10.2.0/0015-Add-LEON-multilibs-for-sparc-zephyr-elf.patch
+++ b/patches/gcc/10.2.0/0015-Add-LEON-multilibs-for-sparc-zephyr-elf.patch
@@ -1,0 +1,96 @@
+From 4beadbc1abc6a2943b541124d391ceb26a1042c4 Mon Sep 17 00:00:00 2001
+From: Martin Aberg <maberg@gaisler.com>
+Date: Wed, 18 Nov 2020 13:18:59 +0100
+Subject: [PATCH] Add LEON multilibs for sparc-zephyr-elf
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Adds the necessary bits for building libraries for the LEON -mcpu
+targets.
+
+Signed-off-by: Martin Åberg <martin.aberg@gaisler.com>
+---
+ gcc/config.gcc            |  3 +++
+ gcc/config/sparc/t-zephyr | 55 +++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 58 insertions(+)
+ create mode 100644 gcc/config/sparc/t-zephyr
+
+diff --git a/gcc/config.gcc b/gcc/config.gcc
+index 6a349965c0af..96a17f7eacbd 100644
+--- a/gcc/config.gcc
++++ b/gcc/config.gcc
+@@ -3273,6 +3273,9 @@ sh-wrs-vxworks)
+ sparc-*-elf*)
+ 	tm_file="${tm_file} dbxelf.h elfos.h newlib-stdint.h sparc/sysv4.h sparc/sp-elf.h"
+ 	case ${target} in
++	    sparc-zephyr*)
++		tmake_file="sparc/t-sparc sparc/t-zephyr"
++		;;
+ 	    *-leon-*)
+ 		tmake_file="sparc/t-sparc sparc/t-leon"
+ 		;;
+diff --git a/gcc/config/sparc/t-zephyr b/gcc/config/sparc/t-zephyr
+new file mode 100644
+index 000000000000..baaff2f0b77d
+--- /dev/null
++++ b/gcc/config/sparc/t-zephyr
+@@ -0,0 +1,55 @@
++# Copyright (C) 2012-2014 Free Software Foundation, Inc.
++#
++# This file is part of GCC.
++#
++# GCC is free software; you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation; either version 3, or (at your option)
++# any later version.
++#
++# GCC is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with GCC; see the file COPYING3.  If not see
++# <http://www.gnu.org/licenses/>.
++
++# Multilibs for Zephyr
++MULTILIB_OPTIONS         =
++MULTILIB_DIRNAMES        =
++
++MULTILIB_OPTIONS        += mcpu=leon/mcpu=leon3/mcpu=leon3v7
++MULTILIB_DIRNAMES       += leon      leon3      leon3v7
++
++MULTILIB_OPTIONS        += msoft-float
++MULTILIB_DIRNAMES       += soft
++
++MULTILIB_OPTIONS        += mflat
++MULTILIB_DIRNAMES       += flat
++
++MULTILIB_MATCHES         = msoft-float=mno-fpu
++
++
++# This is the complete list of multilibs to build
++MULTILIB_REQUIRED       =
++
++
++MULTILIB_REQUIRED += msoft-float
++
++MULTILIB_REQUIRED += mcpu=leon
++MULTILIB_REQUIRED += mcpu=leon/msoft-float
++MULTILIB_REQUIRED += mcpu=leon/mflat
++MULTILIB_REQUIRED += mcpu=leon/msoft-float/mflat
++
++
++MULTILIB_REQUIRED += mcpu=leon3
++MULTILIB_REQUIRED += mcpu=leon3/msoft-float
++MULTILIB_REQUIRED += mcpu=leon3/mflat
++MULTILIB_REQUIRED += mcpu=leon3/msoft-float/mflat
++
++MULTILIB_REQUIRED += mcpu=leon3v7
++MULTILIB_REQUIRED += mcpu=leon3v7/msoft-float
++MULTILIB_REQUIRED += mcpu=leon3v7/mflat
++MULTILIB_REQUIRED += mcpu=leon3v7/msoft-float/mflat
+-- 
+2.11.0
+


### PR DESCRIPTION
Successfully tested with Zephyr sanitycheck on the SPARC board configurations `qemu_leon3`, `gr716a_mini` and `generic_leon3`.


A summary of the differences between `-mcpu` options are given below.

| Option                              | mul/div | casa |
| ----------------------------- |  --- | --- |
| -mcpu=v7 (or no -mcpu=) |        NO     |  NO |
| -mcpu=leon                      | YES   |   NO |
| -mcpu=leon3                    | YES   |   YES |
| -mcpu=leon3v7                 |  NO  |     YES |

`mul/div` means that the compiler will generate multiplication and
division instructions, which is a SPARC V8 feature. There are some
use cases for compiling without `mul/div`:
- If the hardware is synthesized without `mul/div` instructions.
- To reduce interrupt response time on systems with slow `div`.

`casa` means that the compiler generates the atomic compare-and-swap
instruction which is an extension to SPARC V8.

`-mcpu=leon` is equivalent to `-mcpu=v8` except the instruction timing.
`-mcpu=leon` is useful for LEON2 systems. `-mcpu=leon3` is the typical
option for LEON3, LEON4 and LEON5 systems.

The `-mflat` option enables the flag register window model. `SAVE` and
`RESTORE` instructions will not be generated by the compiler. `-mflat` is
ABI compliant with the SPARC ABI.
