### PR TITLE
Fix up patches for MacOS builds

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -37,6 +37,7 @@ if [ "$machine" == "Mac" ]; then
 	if [ ! -d "/Volumes/$ImageName" ]; then
 		hdiutil mount ${ImageNameExt}
 	fi
+	cp -a patches /Volumes/$ImageName
 	cd /Volumes/$ImageName
 fi
 


### PR DESCRIPTION
When we build on MacOS since we create a sparseimage file to do
builds the location of the sdk patches isn't correct.  Fix this
by copying the patches/ dir into the mounted sparseimage file.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>