### PR TITLE
x86_64: fix soft float for x86 32-bit

### DIFF
--- a/patches/gcc/10.2.0/0017-x86_64-zephyr-elf-fix-soft-float-for-x86-32-bit.patch
+++ b/patches/gcc/10.2.0/0017-x86_64-zephyr-elf-fix-soft-float-for-x86-32-bit.patch
@@ -1,0 +1,54 @@
+From df5ca42adff42aff861d4af132c87a3b6aaaf21c Mon Sep 17 00:00:00 2001
+From: Daniel Leung <daniel.leung@intel.com>
+Date: Thu, 10 Dec 2020 10:31:19 -0800
+Subject: [PATCH 17/17] x86_64-zephyr-elf: fix soft float for x86 32-bit
+
+This fixes soft-float build for x86 32-bit (-m32 -msoft-float)
+under x86_64-zephyr-elf multilib build. This now actually
+includes the soft float functions.
+
+Signed-off-by: Daniel Leung <daniel.leung@intel.com>
+---
+ libgcc/config.host             | 9 ++++++++-
+ libgcc/config/i386/64/t-softfp | 2 ++
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+ create mode 100644 libgcc/config/i386/64/t-softfp
+
+diff --git a/libgcc/config.host b/libgcc/config.host
+index 54ae74350..f76f23943 100644
+--- a/libgcc/config.host
++++ b/libgcc/config.host
+@@ -704,7 +704,7 @@ i[34567]86-*-elf*)
+ 	tmake_file="$tmake_file i386/t-crtstuff t-crtstuff-pic t-libgcc-pic"
+ 	;;
+ x86_64-zephyr-elf)
+-	tmake_file="$tmake_file i386/t-crtstuff i386/64/t-zephyr64 t-dfprules"
++	tmake_file="$tmake_file i386/t-crtstuff i386/64/t-zephyr64"
+ 	;;
+ x86_64-*-elf* | x86_64-*-rtems*)
+ 	tmake_file="$tmake_file i386/t-crtstuff t-crtstuff-pic t-libgcc-pic"
+@@ -1528,6 +1528,13 @@ i[34567]86-*-linux* | x86_64-*-linux* | \
+ esac
+ 
+ case ${host} in
++x86_64-zephyr-elf)
++	tmake_file="${tmake_file} t-softfp-sfdf"
++	if test "${host_address}" = 32; then
++		tmake_file="${tmake_file} i386/${host_address}/t-softfp"
++	fi
++	tmake_file="${tmake_file} i386/64/t-softfp i386/t-softfp t-softfp t-dfprules"
++	;;
+ i[34567]86-*-elfiamcu | i[34567]86-zephyr-elf | i[34567]86-*-rtems*)
+ 	# These use soft-fp for SFmode and DFmode, not just TFmode.
+ 	;;
+diff --git a/libgcc/config/i386/64/t-softfp b/libgcc/config/i386/64/t-softfp
+new file mode 100644
+index 000000000..f35d6161b
+--- /dev/null
++++ b/libgcc/config/i386/64/t-softfp
+@@ -0,0 +1,2 @@
++softfp_wrap_start := '\#ifndef __x86_64__'
++softfp_wrap_end := '\#endif'
+-- 
+2.29.2
+


### PR DESCRIPTION
This fixes soft-float build for x86 32-bit (-m32 -msoft-float)
under x86_64-zephyr-elf multilib build. This now actually
includes the soft float functions.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>