### PR TITLE
cmake: updating TOOLCHAIN_ZEPHYR_0_11 --> TOOLCHAIN_ZEPHYR_0_12

### DIFF
--- a/cmake/zephyr/Kconfig
+++ b/cmake/zephyr/Kconfig
@@ -3,6 +3,6 @@
 # Copyright (c) 2020 Linaro Limited.
 # SPDX-License-Identifier: Apache-2.0
 
-config TOOLCHAIN_ZEPHYR_0_11
+config TOOLCHAIN_ZEPHYR_0_12
 	def_bool y
 	select HAS_NEWLIB_LIBC_NANO if (ARC || (ARM && !ARM64) || RISCV)


### PR DESCRIPTION
During release of the Zephyr SDK 0.12, the corresponding Kconfig setting
was missed.

This commit changes `TOOLCHAIN_ZEPHYR_0_11` to `TOOLCHAIN_ZEPHYR_0_12`

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>