### PR TITLE
cmake: Add arm64 cross-compile target

### DIFF
--- a/cmake/zephyr/target.cmake
+++ b/cmake/zephyr/target.cmake
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_ARM64)
+  # Legacy target to support Zephyr versions before the ARM/ARM64 split
   set(CROSS_COMPILE_TARGET_arm         aarch64-zephyr-elf)
 else()
   set(CROSS_COMPILE_TARGET_arm         arm-zephyr-eabi)
 endif()
+set(CROSS_COMPILE_TARGET_arm64   aarch64-zephyr-elf)
 set(CROSS_COMPILE_TARGET_nios2     nios2-zephyr-elf)
 set(CROSS_COMPILE_TARGET_riscv   riscv64-zephyr-elf)
 set(CROSS_COMPILE_TARGET_mips       mips-zephyr-elf)


### PR DESCRIPTION
There is an ongoing effort in Zephyr to separate the ARM architecturefrom ARM64 (AArch64). As part of this work, a new architecture will be introduced called 'arm64'.

To be able to keep using the same SDK to compile old and new Zephyr releases, we need to add a new cross-compile target specifically for 'arm64' together with the legacy 'arm' target.

@galak @tejlmand  this should be a pretty harmless change to be able to support the current situation and at the same time the new changes that I'm going to submit soon, where the ARM64 will be separated from the ARM architecture.