### PR TITLE
crosstool-ng: Update to pull in gcc TM clone registry config

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -12,7 +12,7 @@ if [ "$TARGETS" == "all" ]; then
 	TARGETS=${TARGETS}" tools"
 fi
 
-COMMIT="dded2f648af7eca10223df7b162a1f19c6757759"
+COMMIT="c873543d2f41a6f0053097d52550da501570856b"
 GITDIR=${PWD}
 JOBS=$(python -c 'import multiprocessing as mp; print(mp.cpu_count())')
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -7,6 +7,9 @@
 - newlib:
   * Added multithreading support
 
+- gcc:
+  * Removed libgcc transactional memory clone registry support
+
 ## Zephyr SDK 0.13.0-alpha-1
 
 - general:


### PR DESCRIPTION
Update build script to pull in the crosstool-ng commit that supports
the new `CT_CC_GCC_TM_CLONE_REGISTRY` config option.

This option is disabled by default and will therefore add
`--disable-tm-clone-registry` during gcc build to disable the unused
transactional memory clone registry in libgcc.

For more details, refer to the issue #345.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #345.