### PR TITLE
crosstool-ng: Update to pull in libstdc++ nano config fix

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -9,6 +9,9 @@
 
 - gcc:
   * Removed libgcc transactional memory clone registry support
+  * Fixed incorrect build specs for libstdc++ nano variant. The libstdc++ nano
+    variant, which is used with newlib-nano, is now built with
+    `-fno-exceptions` to reduce compiled binary size.
 
 ## Zephyr SDK 0.13.0-alpha-1
 


### PR DESCRIPTION
Update build script to pull in the crosstool-ng commit that corrects
the build specs for the libstdc++ nano, which is used with newlib-nano.

For more details, refer to the issue #346.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #346