### PR TITLE
ci: Add workflow to build macosx-x86_64 toolchains

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,0 +1,227 @@
+name: macos-ci
+
+on:
+  push:
+
+jobs:
+  # Cancel job is setup to not cancel jobs associated with
+  # a tag (ie a release).  Also we run it on ubuntu in the
+  # hopes that if the macos builders are full that it can
+  # still run
+  cancel:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Cancel Previous Runs"
+        uses: styfle/cancel-workflow-action@0.9.0
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        with:
+          access_token: ${{ github.token }}
+
+  # Crosstool job creates a disk image, builds crosstool so we
+  # only do that once per toolchain, and preloads the disk image with
+  # the sources so we only download them once.
+  #
+  # NOTES:
+  # - uses 'go.sh cmake' as a way to easily just build crosstool
+  # - to download sources we use arm.config and utilize setting
+  #   CT_ONLY_DOWNLOAD in the env plus invoking crosstool with
+  #   a STOP=companion_libs_for_build condition.
+  crosstool:
+    needs: cancel
+    runs-on: ${{ matrix.host }}
+    strategy:
+      matrix:
+        host: [
+          "macos-10.15",
+        ]
+    steps:
+      - name: "clone"
+        uses: actions/checkout@v2
+      - name: "prereq macOS"
+        run: |
+          brew install autoconf automake bash binutils gawk gnu-sed \
+               gnu-tar help2man ncurses
+      - name: "build ct-ng"
+        run: |
+          export HOMEBREW_ROOT="/usr/local"
+          export PATH="$PATH:${HOMEBREW_ROOT}/opt/binutils/bin"
+          export CPPFLAGS="-I${HOMEBREW_ROOT}/opt/ncurses/include -I${HOMEBREW_ROOT}/opt/gettext/include"
+          export LDFLAGS="-L${HOMEBREW_ROOT}/opt/ncurses/lib -L${HOMEBREW_ROOT}/opt/gettext/lib"
+          ./go.sh cmake
+      - name: "preload sources"
+        run: |
+          export GITDIR=${PWD}
+          export SDK_NG_HOME=/Volumes/CrossToolNGNew
+          export CT_NG=${SDK_NG_HOME}/bin/ct-ng
+          export CT_PREFIX=${SDK_NG_HOME}/build/output/
+          export CT_ONLY_DOWNLOAD=y
+          mkdir -p ${SDK_NG_HOME}/build/dummy
+          cd ${SDK_NG_HOME}/build/dummy
+          $CT_NG defconfig DEFCONFIG=${GITDIR}/configs/arm.config
+          $CT_NG build STOP=companion_libs_for_build
+          cd ${GITDIR}
+          rm -fr ${CT_PREFIX}/arm-zephyr-eabi
+          rm -fr ${SDK_NG_HOME}/build/dummy
+      - name: "upload cmake"
+        uses: actions/upload-artifact@v2
+        with:
+          name: cmake.x86_64.tar.bz2
+          path: /Volumes/CrossToolNGNew/cmake.x86_64.tar.bz2
+      - name: "prep to upload"
+        continue-on-error: true
+        run: |
+          sync
+          sleep 10
+          hdiutil unmount /Volumes/CrossToolNGNew -force
+      - name: "upload ct-ng"
+        uses: actions/upload-artifact@v2
+        with:
+          name: CrossToolNGNew.sparseimage
+          path: CrossToolNGNew.sparseimage
+
+  # Build the actual toolchains.  This will publish artifacts for the
+  # toolchain builds and build logs
+  toolchains:
+    needs: crosstool
+    runs-on: ${{ matrix.host }}
+    strategy:
+      matrix:
+        host: [
+          "macos-10.15",
+        ]
+        sample: [
+          "arm",
+          "arc",
+          "riscv64",
+          "nios2",
+          "sparc",
+          "x86_64-zephyr-elf",
+          "arm64",
+          "xtensa_sample_controller",
+          "xtensa_intel_apl_adsp",
+          "xtensa_intel_bdw_adsp",
+          "xtensa_intel_byt_adsp",
+          "xtensa_nxp_imx_adsp",
+          "xtensa_nxp_imx8m_adsp",
+          "xtensa_intel_s1000",
+          "mips",
+        ]
+    steps:
+      - name: "clone"
+        uses: actions/checkout@v2
+      - name: "download ct-ng"
+        uses: actions/download-artifact@v2
+        with:
+          name: CrossToolNGNew.sparseimage
+      - name: "prereq macOS"
+        run: |
+          brew install autoconf automake bash binutils gawk gnu-sed \
+               gnu-tar help2man ncurses pkg-config
+          echo "$GITHUB_WORKSPACE/.local/bin" >> $GITHUB_PATH
+      - name: "prep ${{ matrix.sample }}.config"
+        run: |
+           sed -i -e '/CT_GDB_CROSS_PYTHON_BINARY/d' configs/${{ matrix.sample }}.config
+           sed -i -e '/CT_GDB_CROSS_BUILD_NO_PYTHON/d' configs/${{ matrix.sample }}.config
+           sed -i -e '/^CT_CC_GCC_EXTRA_CONFIG_ARRAY=/ s/"$/ --without-zstd"/' configs/${{ matrix.sample }}.config
+           echo "# CT_GDB_CROSS_PYTHON is not set" >> configs/${{ matrix.sample }}.config
+      - name: "build ${{ matrix.sample }} for ${{ matrix.host }}"
+        run: |
+          ./go.sh ${{ matrix.sample }}
+      - name: "tar"
+        run: |
+          export TARGET=${{ matrix.sample }}
+          export MACHINE=$(uname -m)
+          cd /Volumes/CrossToolNGNew/build/output
+          case "${TARGET}" in
+            xtensa_*)
+              tar --exclude='build.log.bz2' -jcvf ../../${TARGET}.$MACHINE.tar.bz2 xtensa/${TARGET#xtensa_}/*-zephyr-*;
+              ;;
+            *)
+              tar --exclude='build.log.bz2' -jcvf ../../${TARGET}.$MACHINE.tar.bz2 *-zephyr-*;
+              ;;
+          esac
+      - name: "upload xtensa build log"
+        if: ${{ always() && startsWith(matrix.sample, 'xtensa') }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: "${{ matrix.sample }}.${{ matrix.host }}.log"
+          path: /Volumes/CrossToolNGNew/build/output/xtensa/*/*-zephyr-*/build.log.bz2
+      - name: "upload not-xtensa build log"
+        if: ${{ always() && !startsWith(matrix.sample, 'xtensa') }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: "${{ matrix.sample }}.${{ matrix.host }}.log"
+          path: /Volumes/CrossToolNGNew/build/output/*-zephyr-*/build.log.bz2
+      - name: "upload toolchain tarball"
+        uses: actions/upload-artifact@v2
+        with:
+          name: "${{ matrix.sample }}.x86_64.tar.bz2"
+          path: /Volumes/CrossToolNGNew/${{ matrix.sample }}.x86_64.tar.bz2
+
+  # Create the actual zephyr toolchain and SDK packages
+  package:
+    needs: toolchains
+    runs-on: ${{ matrix.host }}
+    strategy:
+      matrix:
+        host: [
+          "macos-10.15",
+        ]
+    steps:
+      - name: "clone"
+        uses: actions/checkout@v2
+      - name: "prereq macOS"
+        run: |
+          brew install makeself
+      - name: mkdir toolchains
+        run: |
+          mkdir -p scripts/toolchains/dl
+      - name: "download ct-ng"
+        uses: actions/download-artifact@v2
+        with:
+          path: scripts/toolchains/dl
+      - name: "cleanup"
+        run: |
+          mv scripts/toolchains/dl/*/*.tar.bz2 scripts/toolchains
+          rm -fr scripts/toolchains/dl
+      - name: "build toolchains"
+        run: |
+          cd scripts
+          ./make_zephyr_sdk.sh x86_64
+      - name: "upload toolchains"
+        uses: actions/upload-artifact@v2
+        with:
+          name: zephyr-toolchains
+          path: scripts/zephyr-toolchain-*
+      - name: "upload sdk"
+        uses: actions/upload-artifact@v2
+        with:
+          name: zephyr-sdk
+          path: scripts/zephyr-sdk-*
+
+  # Publish the zephyr toolchain and SDK packages if we tagged a release
+  release:
+    needs: package
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ${{ matrix.host }}
+    strategy:
+      matrix:
+        host: [
+          "macos-10.15",
+        ]
+    steps:
+      - name: "download toolchains"
+        uses: actions/download-artifact@v2
+        with:
+          name: zephyr-toolchains
+      - name: "download sdk"
+        uses: actions/download-artifact@v2
+        with:
+          name: zephyr-sdk
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            zephyr-*.run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a github workflow that will build macosx-x86_64 toolchains and
publish the packages on release.  The workflow only runs after a
commit since it takes 6+ hours to run on current github macosx
builders.

A few notes / caveats on the macosx toolchain build / packages:

* NO host tools (ie qemu, openocd, dtc, etc).  Since we dont build
  yocto on MacOS we dont currently have any of the host tools at
  this time

* GDB build is without python.  The python GDB on MacOS doesn't
  currently work so we limit GDB to only a non-python enabled
  build.

* gcc build with --without-zstd to make builds portable.  As zstd
  isn't a common library on MacOS we build with this flag since
  it is found in homebrew with the github MacOS setup

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>