### PR TITLE
qemu: Allow setup of ARC's "virt" board memory size

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0018-arc-virt-Make-target-memory-size-configurable.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0018-arc-virt-Make-target-memory-size-configurable.patch
@@ -1,0 +1,73 @@
+From a76ddb02f29a696dd70a251055aacf9956cd8149 Mon Sep 17 00:00:00 2001
+From: Alexey Brodkin <abrodkin@synopsys.com>
+Date: Mon, 9 Aug 2021 06:55:54 -0700
+Subject: [PATCH] arc: virt: Make target memory size configurable
+
+We used to allocate entire usable 2GiB of memory for ARC's "virt" board
+assuming the Linux kernel with its user-space will anyway utilize all that.
+
+But since then "virt" board was accommodated by Zephyr project where much
+smaller apps are being executed and that huge overhead in memory
+footprint started to get in the way.
+
+See https://github.com/zephyrproject-rtos/sdk-ng/issues/291 for example.
+
+With this change one may say "-m 8M" and get only 8 MiB DDR instantiated
+for the simulated board.
+
+Still we keep the same default of 2 GiB in case no "-m" option is given.
+
+Signed-off-by: Alexey Brodkin <abrodkin@synopsys.com>
+---
+ hw/arc/virt.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/hw/arc/virt.c b/hw/arc/virt.c
+index 5ba05b6452..e2132671f7 100644
+--- a/hw/arc/virt.c
++++ b/hw/arc/virt.c
+@@ -14,6 +14,7 @@
+  */
+ 
+ #include "qemu/osdep.h"
++#include "qemu/units.h"
+ #include "qapi/error.h"
+ #include "boot.h"
+ #include "hw/boards.h"
+@@ -26,7 +27,6 @@
+ #include "hw/sysbus.h"
+ 
+ #define VIRT_RAM_BASE      0x80000000
+-#define VIRT_RAM_SIZE      0x80000000
+ #define VIRT_IO_BASE       0xf0000000
+ #define VIRT_IO_SIZE       0x10000000
+ #define VIRT_UART0_OFFSET  0x0
+@@ -115,7 +115,7 @@ static void virt_init(MachineState *machine)
+     int n;
+ 
+     boot_info.ram_start = VIRT_RAM_BASE;
+-    boot_info.ram_size = VIRT_RAM_SIZE;
++    boot_info.ram_size = machine->ram_size;
+     boot_info.kernel_filename = machine->kernel_filename;
+     boot_info.kernel_cmdline = machine->kernel_cmdline;
+ 
+@@ -139,7 +139,7 @@ static void virt_init(MachineState *machine)
+ 
+     /* Init system DDR */
+     system_ram = g_new(MemoryRegion, 1);
+-    memory_region_init_ram(system_ram, NULL, "arc.ram", VIRT_RAM_SIZE,
++    memory_region_init_ram(system_ram, NULL, "arc.ram", machine->ram_size,
+                            &error_fatal);
+     memory_region_add_subregion(system_memory, VIRT_RAM_BASE, system_ram);
+ 
+@@ -175,6 +175,7 @@ static void virt_machine_init(MachineClass *mc)
+     mc->init = virt_init;
+     mc->max_cpus = 1;
+     mc->is_default = true;
++    mc->default_ram_size = 2 * GiB;
+ }
+ 
+ DEFINE_MACHINE("virt", virt_machine_init)
+-- 
+2.16.2
+

--- a/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
@@ -27,6 +27,7 @@ SRC_URI = "git://github.com/qemu/qemu.git;protocol=https \
 	   file://0015-hw-arm-mps2-tz-Allow-board-to-specify-a-boot-RAM-siz.patch \
 	   file://0016-hw-arm-Model-TCMs-in-the-SSE-300-not-the-AN547.patch \
 	   file://0017-target-arm-Use-correct-SP-in-M-profile-exception-ret.patch \
+	   file://0018-arc-virt-Make-target-memory-size-configurable.patch \
 "
 
 SRC_URI[bios-128k.sha256sum] = "943c077c3925ee7ec85601fb12937a0988c478a95523a628cd7e61c639dd6e81"


### PR DESCRIPTION
We used to be very generous with memory allocation for ARC's "virt" board assuming people would run Linux on it and all 2 GiB of RAM will be consumed anyway.

But in case of Zephyr we don't need that much, yet QEMU tries to allocate 2 GiB right away meaninglessly claiming hosts's memory.

And while it's typically not a big deal if 1 QEMU instance is run on an up-to-date host (we have 10s of GiBs to our disposal), in case of massive parallel QEMU execution like in Zephyr's "twister", it really starts to get in a way. So we now allow user to specify amount of memory we'd like to have on emulated target and thus significantly lower memory pressure and requirements on "twister"-running hosts.

Fixes https://github.com/zephyrproject-rtos/sdk-ng/issues/291.