### PR TITLE
[RFC] meta-zephyr-sdk: xilinx_qemu: Enable "microblazeel" emulation target

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
@@ -243,6 +243,7 @@ do_configure() {
 
 do_install_append() {
     ln -sf ../xilinx/bin/qemu-system-aarch64 ${D}${bindir}/qemu-system-xilinx-aarch64
+    ln -sf ../xilinx/bin/qemu-system-microblazeel ${D}${bindir}/qemu-system-xilinx-microblazeel
 }
 
 FILES_${PN} = " \

--- a/meta-zephyr-sdk/recipes-devtools/xilinx_qemu/xilinx-qemu_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/xilinx_qemu/xilinx-qemu_git.bb
@@ -194,7 +194,7 @@ inherit autotools pkgconfig
 
 #--disable-fdt: Cannot use if supporting arm-generic-fdt machine type
 
-QEMUS_BUILT = "aarch64-softmmu"
+QEMUS_BUILT = "aarch64-softmmu microblazeel-softmmu"
 QEMU_FLAGS = "--disable-docs  --disable-sdl --disable-debug-info  --disable-cap-ng \
   --disable-libnfs --disable-libusb --disable-libiscsi --disable-usb-redir --disable-linux-aio \
   --disable-guest-agent --disable-libssh --disable-vnc-png  --disable-seccomp \

--- a/release-notes.md
+++ b/release-notes.md
@@ -5,6 +5,7 @@
 - qemu:
   * Added MIPS little endian emulation
   * Update xilinx qemu to 5.1.0
+  * Added Xilinx MicroBlaze little endian emulation
 
 ## Zephyr SDK 0.13.1
 - gdb:


### PR DESCRIPTION
MicroBlaze emulation is needed to boot a Linux on a Xilinx zcu102
target, which is in turn useful for end-to-end demonstration of
OpenAMP capabilities (Linux host boots a (Zephyr) image on a
remote processor and interacts with it).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>