### PR TITLE
config: Disable the GP register optimizations on MIPS

### DIFF
--- a/configs/mips.config
+++ b/configs/mips.config
@@ -5,6 +5,7 @@ CT_LOCAL_TARBALLS_DIR="${CT_PREFIX:-${HOME}/x-tools}/sources"
 # CT_LOG_PROGRESS_BAR is not set
 CT_ARCH_MIPS=y
 CT_MULTILIB=y
+CT_TARGET_CFLAGS="-G0 -mno-gpopt"
 CT_TARGET_VENDOR="zephyr"
 CT_BINUTILS_SRC_DEVEL=y
 CT_BINUTILS_DEVEL_URL="https://github.com/zephyrproject-rtos/binutils-gdb.git"

--- a/release-notes.md
+++ b/release-notes.md
@@ -4,6 +4,8 @@
 
 - gcc:
   * Added multilibs for the RISC-V RV32E targets.
+  * Disabled MIPS GP register optimisation, which is not supported by the
+    Zephyr MIPS architecture port.
 
 - newlib:
   * Enabled C99 format specifier support for newlib full variant.


### PR DESCRIPTION
This change turns off the use of the GP register for small data values on MIPS.
This allows a few more testcases to pass.

Signed-off-by: Remy Luisant <remy@luisant.ca>