### PR TITLE
openocd: Pull in OpenOCD fixes

### DIFF
--- a/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_0.10.0.bb
+++ b/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_0.10.0.bb
@@ -9,7 +9,7 @@ RDEPENDS_${PN} = "libusb1 hidapi"
 SRC_URI = " \
 	git://github.com/zephyrproject-rtos/openocd.git;protocol=https;nobranch=1 \
 	"
-SRCREV = "7036ed509aa7297262eb7b91062e849bedcfed39"
+SRCREV = "7e3dbbbe231903ca25e7f7a5a782a34111ccc8bd"
 
 S = "${WORKDIR}/git"
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -10,6 +10,10 @@
   * Update xilinx qemu to 5.1.0
   * Added Xilinx MicroBlaze little endian emulation
 
+- openocd:
+  * Fixed missing DBG clock on STM32G0/L0.
+  * Fixed image verification for ARC.
+
 ## Zephyr SDK 0.13.1
 - gdb:
   * Fix ELF file format support issue on MacOS


### PR DESCRIPTION
Pull in the following OpenOCD fixes:

* tfc/target: stm32: Fix missing DBG clock on stm32g0/l0
* target/arc: implement dummy checksum_memory()

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>