### PR TITLE
meta-zephyr-sdk: Fix component source URIs

### DIFF
--- a/meta-zephyr-sdk/recipes-core/expat/expat_%.bbappend
+++ b/meta-zephyr-sdk/recipes-core/expat/expat_%.bbappend
@@ -1,0 +1,6 @@
+# Override the source URL for expat since the old mirror specified in the meta
+# layer is no longer available.
+
+VERSION_TAG = "${@d.getVar('PV').replace('.', '_')}"
+
+SRC_URI_prepend = "https://github.com/libexpat/libexpat/releases/download/R_${VERSION_TAG}/expat-${PV}.tar.bz2 "

--- a/meta-zephyr-sdk/recipes-support/libpcre/libpcre2_%.bbappend
+++ b/meta-zephyr-sdk/recipes-support/libpcre/libpcre2_%.bbappend
@@ -1,0 +1,4 @@
+# Override the source URL for libpcre2 since the old mirror specified in the
+# meta layer is no longer available.
+
+SRC_URI_prepend = "https://github.com/PhilipHazel/pcre2/releases/download/pcre2-${PV}/pcre2-${PV}.tar.bz2 "

--- a/meta-zephyr-sdk/recipes-support/libpcre/libpcre_%.bbappend
+++ b/meta-zephyr-sdk/recipes-support/libpcre/libpcre_%.bbappend
@@ -1,0 +1,4 @@
+# Override the source URL for libpcre since the old mirror specified in the
+# meta layer is no longer available.
+
+SRC_URI_prepend = "${SOURCEFORGE_MIRROR}/pcre/pcre-${PV}.tar.bz2 "


### PR DESCRIPTION
```
meta-zephyr-sdk: Fix libpcre source URI

This commit updates the source URI for the libpcre and libpcre2
components by overriding the SRC_URI variable specified in the meta
layer.

Note that the old mirror specified in the meta layer is no longer
available and has officially been relocated to GitHub [1].

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

[1] https://pcre.org/
```

```
meta-zephyr-sdk: Fix expat source URI

This commit updates the source URI for the expat component by
overriding the SRC_URI variable specified in the meta layer.

Note that the old mirror specified in the meta layer is no longer
available and has officially been relocated to GitHub [1].

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

[1] https://github.com/libexpat/libexpat
```

Fixes #427
Fixes #429 