### PR TITLE
ci: Add matrix-less checkpoint for test result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1279,3 +1279,21 @@ jobs:
         name: test_${{ matrix.testenv.name }}_${{ matrix.subset }}
         if-no-files-found: ignore
         path: test/twister-out/twister.xml
+
+  # Post test result check
+  test-result:
+    name: Test Result
+    needs: [ test-dist-bundle ]
+    runs-on: ubuntu-20.04
+
+    # NOTE: The 'test-result' job depends on the 'test-dist-bundle' job and
+    #       therefore only runs when all distribution bundle tests pass.
+    #
+    #       The purpose of this job is to provide a checkpoint which the GitHub
+    #       branch protection rule can use to enforce the required checks for
+    #       merging pull requests, because GitHub does not support specifying a
+    #       job that is part of a matrix for this purpose.
+    steps:
+    - name: Summary
+      run: |
+        echo "All passed"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
   release:
     types: [ published ]
 
+permissions:
+  contents: write
+
 env:
   BUNDLE_PREFIX: zephyr-sdk
 


### PR DESCRIPTION
This commit adds a new job to the CI workflow that is not a part of a
matrix and depends on the distribution bundle test matrix jobs, such
that it only runs when the distribution bundle test jobs do not fail
(i.e. all distribution bundle tests pass).

The purpose of this is to provide a checkpoint which the GitHub branch
protection rule can use to enforce the required checks for merging pull
requests, because GitHub does not support specifying a job that is part
of a matrix for this purpose.

Remove this when GitHub is updated to support specifying the steps that
are part of matrix jobs for the required checks.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Tested in https://github.com/zephyrproject-rtos/sdk-ng-testing/pull/3.

NOTE: "Test Result" job should be added to the required check list in the main branch protection rule after this is merged.