### PR TITLE
scripts: Fix incorrect Linux host tools setup invocation

### DIFF
--- a/scripts/template_setup_posix
+++ b/scripts/template_setup_posix
@@ -102,7 +102,7 @@ if [ "${do_hosttools}" = "y" ]; then
   echo "Installing host tools ..."
   case ${OSTYPE} in
     linux-gnu*)
-      ./zephyr-sdk-x86_64-hosttools-standalone-0.9.sh -y -d .
+      ./zephyr-sdk-${HOSTTYPE}-hosttools-standalone-0.9.sh -y -d .
       ;;
     darwin*)
       echo "SKIPPED: macOS host tools are not available yet."


### PR DESCRIPTION
When invoking the host tools setup SFX, the POSIX setup script
incorrectly assumed that the host architecture for Linux is always
x86-64.

This commit updates the setup script to invoke the host tools setup SFX
of the host architecture that is running the script.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #438