### PR TITLE
qemu: Pull in I2C device emulation support for ARM targets

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
@@ -5,7 +5,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
                     file://COPYING.LIB;endline=24;md5=8c5efda6cf1e1b03dcfd0e6c0d271c7f"
 
-SRCREV = "59f1efa351fefd631650a9a49da64fa082103ac2"
+SRCREV = "d68d2375d820106e38aad330aad46495a2dde885"
 SRC_URI = "git://github.com/zephyrproject-rtos/qemu.git;protocol=https;nobranch=1 \
 	   https://github.com/zephyrproject-rtos/seabios/releases/download/zephyr-v1.0.0/bios-128k.bin;name=bios-128k \
 	   https://github.com/zephyrproject-rtos/seabios/releases/download/zephyr-v1.0.0/bios-256k.bin;name=bios-256k \

--- a/release-notes.md
+++ b/release-notes.md
@@ -4,6 +4,7 @@
 
 - qemu:
   * Updated to QEMU 6.2 release.
+  * Added I2C device emulation support for ARM targets.
 
 ## Zephyr SDK 0.14.0
 


### PR DESCRIPTION
This commit pulls in the patches required to support the emulation of
the I2C devices (e.g. LSM303DLHC magnetometer) on the ARM targets.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

QEMU PR: https://github.com/zephyrproject-rtos/qemu/pull/4