### PR TITLE
ci: Pull Docker images from GitHub Container Registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
           MATRIX_HOSTS+='{
               "name": "linux-x86_64",
               "runner": "zephyr_runner",
-              "container": "zephyrprojectrtos/sdk-build:v1.2.0",
+              "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.2.1",
               "archive": "tar.gz"
             },'
         fi
@@ -188,7 +188,7 @@ jobs:
           MATRIX_HOSTS+='{
               "name": "linux-aarch64",
               "runner": "zephyr_runner",
-              "container": "zephyrprojectrtos/sdk-build:v1.2.0",
+              "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.2.1",
               "archive": "tar.gz"
             },'
         fi
@@ -215,7 +215,7 @@ jobs:
           MATRIX_HOSTS+='{
               "name": "windows-x86_64",
               "runner": "zephyr_runner",
-              "container": "zephyrprojectrtos/sdk-build:v1.2.0",
+              "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.2.1",
               "archive": "zip"
             },'
         fi


### PR DESCRIPTION
This commit updates the CI workflow to pull the Docker images from the
GitHub Container Registry (GHCR) to work around the pull rate limits of
the DockerHub.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>