### PR TITLE
ci: release: Pass secrets to reusable workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
   pull_request_target:
     branches: [ main ]
   workflow_call:
+    secrets:
+      AWS_CACHE_SDK_ACCESS_KEY_ID:
+        required: true
+      AWS_CACHE_SDK_SECRET_ACCESS_KEY:
+        required: true
   workflow_dispatch:
     inputs:
       zephyr-ref:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
   ci:
     name: CI
     uses: ./.github/workflows/ci.yml
+    secrets:
+      AWS_CACHE_SDK_ACCESS_KEY_ID: ${{ secrets.AWS_CACHE_SDK_ACCESS_KEY_ID }}
+      AWS_CACHE_SDK_SECRET_ACCESS_KEY: ${{ secrets.AWS_CACHE_SDK_SECRET_ACCESS_KEY }}
 
   # Publish release assets
   release:


### PR DESCRIPTION
This commit updates the release workflow to explicitly pass the secrets
to the reusable CI workflow (invoked via `workflow_call`) because the
repository secrets are not available by default in the reusable
workflows.