### PR TITLE
ci: Fix pull request checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,17 @@ jobs:
 
     steps:
     - name: Check out source code
+      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/checkout@v2
       with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Check out source code (pull request)
+      if: ${{ github.event_name == 'pull_request_target' }}
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
         persist-credentials: false
 
@@ -484,8 +493,17 @@ jobs:
         echo "WORKSPACE=${WORKSPACE}" >> $GITHUB_ENV
 
     - name: Check out source code
+      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/checkout@v2
       with:
+        submodules: recursive
+        persist-credentials: false
+
+    - name: Check out source code (pull request)
+      if: ${{ github.event_name == 'pull_request_target' }}
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
         submodules: recursive
         persist-credentials: false
 
@@ -791,8 +809,17 @@ jobs:
         echo "TAR=gtar" >> $GITHUB_ENV
 
     - name: Check out source code
+      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/checkout@v2
       with:
+        submodules: recursive
+        persist-credentials: false
+
+    - name: Check out source code (pull request)
+      if: ${{ github.event_name == 'pull_request_target' }}
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
         submodules: recursive
         persist-credentials: false
 
@@ -931,8 +958,16 @@ jobs:
         echo "TAR=gtar" >> $GITHUB_ENV
 
     - name: Check out source code
+      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/checkout@v2
       with:
+        persist-credentials: false
+
+    - name: Check out source code (pull request)
+      if: ${{ github.event_name == 'pull_request_target' }}
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
 
     - name: Build CMake package
@@ -1012,8 +1047,17 @@ jobs:
         echo "TAR=gtar" >> $GITHUB_ENV
 
     - name: Check out source code
+      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/checkout@v2
       with:
+        path: repository
+        persist-credentials: false
+
+    - name: Check out source code (pull request)
+      if: ${{ github.event_name == 'pull_request_target' }}
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
         path: repository
         persist-credentials: false
 


### PR DESCRIPTION
The commit 2fc95f5c1a04f5d606ed4aaa4af6b877b71f99fe modified the CI
workflow to use the `pull_request_target` trigger for the pull request
runs.

The `pull_request_target` action runs in the context of the target
branch and the GitHub `checkout` action will check out the target
branch commit by default, thereby not building the actual changes in
the pull request branch.

This commit updates the `checkout` action to check out the pull request
head commit when running in the context of `pull_request_target`.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>