### PR TITLE
crosstool-ng: Pull in crosstool-ng 1.25.0 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,7 +629,7 @@ jobs:
         # Configure GDB Python scripting support
         cat <<EOF >> .config
         CT_GDB_CROSS_PYTHON=y
-        CT_GDB_CROSS_BUILD_NO_PYTHON=y
+        CT_GDB_CROSS_PYTHON_VARIANT=y
         EOF
 
         if [ "${{ matrix.host.name }}" == "linux-aarch64" ]; then


### PR DESCRIPTION
This commit updates the crosstool-ng submodule to track the Zephyr
branch based on the crosstool-ng 1.25.0 release
(`zephyr-crosstool-ng-1.25.0`).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Closes #471