### PR TITLE
meta-zephyr-sdk: openocd: Pull in Cyclone V SoC JTAG device order fix

### DIFF
--- a/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_0.10.0.bb
+++ b/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_0.10.0.bb
@@ -9,7 +9,7 @@ RDEPENDS_${PN} = "libusb1 hidapi"
 SRC_URI = " \
 	git://github.com/zephyrproject-rtos/openocd.git;protocol=https;nobranch=1 \
 	"
-SRCREV = "7e3dbbbe231903ca25e7f7a5a782a34111ccc8bd"
+SRCREV = "af169e805396e5f7ab926aa32ba293a618a894f7"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This commit pulls in the OpenOCD patch that fixes the JTAG device order
for the Intel Cyclone V SoC.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>