### PR TITLE
ci: Force twister color output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1468,7 +1468,7 @@ jobs:
 
         # Run tests with twister
         TWISTER="${ZEPHYR_ROOT}/scripts/twister"
-        ${TWISTER} -v -N -M --inline-logs --retry-failed 3 \
+        ${TWISTER} -v -N -M --force-color --inline-logs --retry-failed 3 \
                    --subset ${{ matrix.subset }}/${{ env.SUBSET_COUNT }} \
                    ${HOST_ARGS} \
                    ${TEST_ARGS} \


### PR DESCRIPTION
This commit updates the CI workflow to invoke the twister with the
`--force-color` option so that the test logs are displayed in color
in the GitHub Actions web console.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>