### PR TITLE
ci: Use Zephyr topic-sdk15 branch for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
       zephyr-ref:
         description: 'Zephyr Ref (branch, tag, SHA, ...)'
         required: true
-        default: main
+        default: topic-sdk15
       host:
         description: 'Host'
         type: choice


### PR DESCRIPTION
This commit updates the CI workflow to use the Zephyr `topic-sdk15`
branch, which contains the Zephyr-side patches required for the
upcoming Zephyr SDK 0.15.0 release, for testing.

Revert this patch when the Zephyr SDK 0.15.0 is release and all the
tasks documented in zephyrproject-rtos/zephyr#46491 are completed.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>