### PR TITLE
ci: Use Zephyr topic-sdk15 branch for testing [v2]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ env:
   BUG_URL: 'https://github.com/zephyrproject-rtos/sdk-ng/issues'
   BUNDLE_NAME: Zephyr SDK
   BUNDLE_PREFIX: zephyr-sdk
-  ZEPHYR_REF: main
+  ZEPHYR_REF: topic-sdk15
 
 jobs:
   # Setup


### PR DESCRIPTION
This commit updates the CI workflow to use the Zephyr `topic-sdk15`
branch, which contains the Zephyr-side patches required for the
upcoming Zephyr SDK 0.15.0 release, for testing.

Revert this patch when the Zephyr SDK 0.15.0 is release and all the
tasks documented in zephyrproject-rtos/zephyr#46491 are completed.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>