### PR TITLE
ci: Disable ARC targets until the latest patches are available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,8 +164,9 @@ jobs:
 
         if [ "${build_target_all}" == "y" ]; then
           build_target_aarch64_zephyr_elf="y"
-          build_target_arc64_zephyr_elf="y"
-          build_target_arc_zephyr_elf="y"
+          # FIXME: Re-enable ARC when the patches for the latest toolchains are available
+          # build_target_arc64_zephyr_elf="y"
+          # build_target_arc_zephyr_elf="y"
           build_target_arm_zephyr_eabi="y"
           build_target_mips_zephyr_elf="y"
           build_target_nios2_zephyr_elf="y"


### PR DESCRIPTION
This commit disables the following ARC targets because the patches for
the latest GNU toolchain components are not currently available:

* arc-zephyr-elf
* arc64-zephyr-elf

Revert this after all toolchain components are updated to include the
ARC patches.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>