### PR TITLE
scripts: template: Disable ARC targets

### DIFF
--- a/scripts/template_setup_posix
+++ b/scripts/template_setup_posix
@@ -118,8 +118,9 @@ pushd "$(dirname "${BASH_SOURCE[0]}")"
 # Initialise toolchain list
 toolchains=(
   "aarch64-zephyr-elf"
-  "arc64-zephyr-elf"
-  "arc-zephyr-elf"
+  # FIXME: Re-enable ARC when the patches for the latest toolchains are available
+  # "arc64-zephyr-elf"
+  # "arc-zephyr-elf"
   "arm-zephyr-eabi"
   "mips-zephyr-elf"
   "nios2-zephyr-elf"

--- a/scripts/template_setup_win
+++ b/scripts/template_setup_win
@@ -26,8 +26,9 @@ exit /b 0
 REM # Initialise toolchain list
 set TOOLCHAINS=
 set TOOLCHAINS=%TOOLCHAINS% aarch64-zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% arc64-zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% arc-zephyr-elf
+REM # FIXME: Re-enable ARC when the patches for the latest toolchains are available
+REM set TOOLCHAINS=%TOOLCHAINS% arc64-zephyr-elf
+REM set TOOLCHAINS=%TOOLCHAINS% arc-zephyr-elf
 set TOOLCHAINS=%TOOLCHAINS% arm-zephyr-eabi
 set TOOLCHAINS=%TOOLCHAINS% mips-zephyr-elf
 set TOOLCHAINS=%TOOLCHAINS% nios2-zephyr-elf


### PR DESCRIPTION
This commit disables the following ARC targets because the patches for
the latest GNU toolchain components are not currently available:

* arc-zephyr-elf
* arc64-zephyr-elf

Revert this after all toolchain components are updated to include the
ARC patches.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>