### PR TITLE
ci: Add option to start debug session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,15 @@ on:
         - xtensa-nxp_imx_adsp_zephyr-elf
         - xtensa-nxp_imx8m_adsp_zephyr-elf
         - xtensa-sample_controller_zephyr-elf
+      debug:
+        description: 'Debug'
+        type: choice
+        required: true
+        options:
+        - none
+        - toolchain-pre
+        - toolchain-post
+        - hosttools
 
 concurrency:
   group: ${{ github.event_name == 'workflow_dispatch' && github.run_id || github.head_ref || github.ref }}
@@ -74,6 +83,7 @@ jobs:
       hosts: ${{ steps.generate-matrix.outputs.hosts }}
       targets: ${{ steps.generate-matrix.outputs.targets }}
       testenvs: ${{ steps.generate-matrix.outputs.testenvs }}
+      debug: ${{ steps.generate-matrix.outputs.debug }}
 
     steps:
     - name: Check out source code
@@ -116,6 +126,11 @@ jobs:
 
           # Build all targets for pull requests
           build_target_all="y"
+
+          # Set debug mode based on the pull request labels
+          ${{ contains(github.event.pull_request.labels.*.name, 'debug-toolchain-pre') }} && MATRIX_DEBUG="toolchain-pre"
+          ${{ contains(github.event.pull_request.labels.*.name, 'debug-toolchain-post') }} && MATRIX_DEBUG="toolchain-post"
+          ${{ contains(github.event.pull_request.labels.*.name, 'debug-hosttools') }} && MATRIX_DEBUG="hosttools"
         elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
           # Set configurations based on the user selection
           case '${{ github.event.inputs.host }}' in
@@ -148,6 +163,8 @@ jobs:
             xtensa-nxp_imx8m_adsp_zephyr-elf)     build_target_xtensa_nxp_imx8m_adsp_zephyr_elf="y";;
             xtensa-sample_controller_zephyr-elf)  build_target_xtensa_sample_controller_zephyr_elf="y";;
           esac
+
+          MATRIX_DEBUG="${{ github.event.inputs.debug }}"
         else
           # Build all for pushes and releases
           build_host_all="y"
@@ -315,6 +332,7 @@ jobs:
         echo "::set-output name=hosts::${MATRIX_HOSTS}"
         echo "::set-output name=targets::${MATRIX_TARGETS}"
         echo "::set-output name=testenvs::${MATRIX_TESTENVS}"
+        echo "::set-output name=debug::${MATRIX_DEBUG}"
 
         # Prepare configuration report
         CONFIG_REPORT=${RUNNER_TEMP}/config-report.txt
@@ -572,6 +590,12 @@ jobs:
         # Export environment variables
         echo "SRC_CACHE_URI=${SRC_CACHE_URI}" >> $GITHUB_ENV
 
+    - name: Setup debug session (pre)
+      if: always() && needs.setup.outputs.debug == 'toolchain-pre'
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
+
     - name: Build toolchain
       run: |
         # Set output path
@@ -741,6 +765,12 @@ jobs:
         md5sum ${ARCHIVE_FILE} > md5.sum
         sha256sum ${ARCHIVE_FILE} > sha256.sum
 
+    - name: Setup debug session (post)
+      if: always() && needs.setup.outputs.debug == 'toolchain-post'
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
+
     - name: Sync downloaded source files to cache
       continue-on-error: true
       run: |
@@ -885,6 +915,12 @@ jobs:
         # Compute checksum
         md5sum ${ARCHIVE_FILE} > md5.sum
         sha256sum ${ARCHIVE_FILE} > sha256.sum
+
+    - name: Setup debug session
+      if: always() && needs.setup.outputs.debug == 'hosttools'
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
 
     - name: Sync downloaded source files to cache (Linux)
       if: startsWith(matrix.host.name, 'linux-')


### PR DESCRIPTION
This commit adds an option to start debug session from a runner when
manually starting the CI workflow through the `workflow_dispatch`
event or in a pull request by setting a debug label.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>