### PR TITLE
ci: Increase macOS workspace volume size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,7 +483,7 @@ jobs:
 
         # Create case-sensitive workspace volume for macOS
         hdiutil create ${RUNNER_TEMP}/Workspace.sparseimage \
-                       -volname Workspace -type SPARSE -size 50g -fs HFSX
+                       -volname Workspace -type SPARSE -size 70g -fs HFSX
         hdiutil mount ${RUNNER_TEMP}/Workspace.sparseimage -mountpoint ${WORKSPACE}
 
         # Install required dependencies if running inside a GitHub-hosted runner


### PR DESCRIPTION
This commit increases the macOS workspace volume size to 70GB because
the current size of 50GB is insufficient and causes "no space left"
error during AArch64 macOS host toolchain builds.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>