### PR TITLE
qemu: Update to QEMU 7.0 release

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/zephyr-qemu_git.bb
@@ -5,7 +5,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
                     file://COPYING.LIB;endline=24;md5=8c5efda6cf1e1b03dcfd0e6c0d271c7f"
 
-SRCREV = "d68d2375d820106e38aad330aad46495a2dde885"
+SRCREV = "2cc2e86de6e0e4316265d34e8e935afade8c422e"
 SRC_URI = "git://github.com/zephyrproject-rtos/qemu.git;protocol=https;nobranch=1 \
 	   https://github.com/zephyrproject-rtos/seabios/releases/download/zephyr-v1.0.0/bios-128k.bin;name=bios-128k \
 	   https://github.com/zephyrproject-rtos/seabios/releases/download/zephyr-v1.0.0/bios-256k.bin;name=bios-256k \


### PR DESCRIPTION
This commit updates the QEMU version to 7.0.0.

QEMU 7.0 is required to support the new ratified RISC-V extensions such
as Zve* and Zb*.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Closes #480