### PR TITLE
ci: Add RISC-V rv32e test platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1458,6 +1458,7 @@ jobs:
               ;;
             riscv64-zephyr-elf)
               PLATFORM_ARGS+="-p qemu_riscv32 "
+              PLATFORM_ARGS+="-p qemu_riscv32e "
               PLATFORM_ARGS+="-p qemu_riscv64 "
               ;;
             sparc-zephyr-elf)


### PR DESCRIPTION
This commit adds the `qemu_riscv32e` to the test platform list for the
`riscv64-zephyr-elf` toolchain so that all supported base RISC-V
architecture variants are tested.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>