### PR TITLE
ARC: ARCv3: fix toolchain prefix for ARCv3 32bit

### DIFF
--- a/cmake/zephyr/target.cmake
+++ b/cmake/zephyr/target.cmake
@@ -14,7 +14,7 @@ set(CROSS_COMPILE_TARGET_xtensa   xtensa-${SOC_TOOLCHAIN_NAME}_zephyr-elf)
 
 # ARC uses the same source tree for both ARCv2 & ARCv3 architectures,
 # while toolchain differ significantly and so their cross-compile prefixes
-if(CONFIG_ISA_ARCV3 AND CONFIG_64BIT)
+if(CONFIG_ISA_ARCV3)
 set(CROSS_COMPILE_TARGET_arc       arc64-zephyr-elf)
 else()
 set(CROSS_COMPILE_TARGET_arc         arc-zephyr-elf)


### PR DESCRIPTION
Both 32bit and 64bit ARCv3 have same toolchain prefix - `arc64-zephyr-elf`