### PR TITLE
ci: Replace intel_s1000_crb with intel_adsp_cavs18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1483,7 +1483,7 @@ jobs:
               # NOTE: no default user for this target is available
               ;;
             xtensa-intel_s1000_zephyr-elf)
-              PLATFORM_ARGS+="-p intel_s1000_crb "
+              PLATFORM_ARGS+="-p intel_adsp_cavs18 "
               ;;
             xtensa-nxp_imx_adsp_zephyr-elf)
               PLATFORM_ARGS+="-p nxp_adsp_imx8 "


### PR DESCRIPTION
The `intel_s1000_crb` platform support, which is currently used for
testing the Intel S1000 Xtensa toolchain, has been removed from the
upstream Zephyr.

This commit updates the CI workflow to test the Intel S1000 Xtensa
toolchain using the `intel_adsp_cavs18` platform, which is another
board that builds using this toolchain.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>