### PR TITLE
meta-zephyr-sdk: arc_qemu: Update to 2022.08.04 release

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/arc_qemu/arc-qemu_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/arc_qemu/arc-qemu_git.bb
@@ -5,7 +5,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
                     file://COPYING.LIB;endline=24;md5=8c5efda6cf1e1b03dcfd0e6c0d271c7f"
 
-SRCREV = "7772126b19fb09a377f942254fef40c3555d92ca"
+SRCREV = "4dad023e2a33b8024abf770f69a122ee5d5e2c9c"
 SRC_URI = "git://github.com/foss-for-synopsys-dwc-arc-processors/qemu.git;protocol=https;nobranch=1 \
 	   file://cross.patch \
 "


### PR DESCRIPTION
This commit updates the ARC QEMU to 2022.08.04 tag.

Closes #481