### PR TITLE
ci: Add container owner mismatch workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -816,6 +816,14 @@ jobs:
         host: ${{ fromJSON(needs.setup.outputs.hosts) }}
 
     steps:
+    - name: Apply container owner mismatch workaround
+      run: |
+        # FIXME: The owner UID of the GITHUB_WORKSPACE directory may not
+        #        match the container user UID because of the way GitHub
+        #        Actions runner is implemented. Remove this workaround when
+        #        GitHub comes up with a fundamental fix for this problem.
+        git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
     - name: Set up build environment (Linux)
       if: ${{ runner.os == 'Linux' }}
       run: |


### PR DESCRIPTION
The owner UID of the GITHUB_WORKSPACE directory may not match the
container user UID because of the way GitHub Actions runner is
implemented, and this can cause the Git operations to fail unless the
workspace directory is explicitly listed as a "safe directory."

For more details, refer to the following GitHub issue:

actions/checkout#760

Remove this workaround when GitHub comes up with a fundamental fix for
this problem.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>