### PR TITLE
ci: Add runner temp directory to git safe directory list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -823,6 +823,7 @@ jobs:
         #        Actions runner is implemented. Remove this workaround when
         #        GitHub comes up with a fundamental fix for this problem.
         git config --global --add safe.directory ${GITHUB_WORKSPACE}
+        git config --global --add safe.directory ${RUNNER_TEMP}
 
     - name: Set up build environment (Linux)
       if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
This commit adds the GitHub runner temporary directory (`RUNNER_TEMP`)
to the Git safe directory list because the `meta-zephyr-sdk` build
process may check out source files under this directory.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>