### PR TITLE
riscv: add library support for RV32IAFC

### DIFF
--- a/configs/riscv64-zephyr-elf.config
+++ b/configs/riscv64-zephyr-elf.config
@@ -29,7 +29,7 @@ CT_LIBC_NEWLIB_RETARGETABLE_LOCKING=y
 CT_LIBC_NEWLIB_EXTRA_SECTIONS=y
 CT_GCC_SRC_CUSTOM=y
 CT_GCC_CUSTOM_LOCATION="${GITHUB_WORKSPACE}/gcc"
-CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array"
+CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array --with-multilib-generator=rv32i-ilp32--c\;rv32im-ilp32--c\;rv32iac-ilp32--f\;rv32imac-ilp32--\;rv32imafc-ilp32f-rv32imafdc-\;rv64imac-lp64--\;rv64imafdc-lp64d--"
 CT_CC_LANG_CXX=y
 CT_DEBUG_GDB=y
 CT_GDB_SRC_CUSTOM=y


### PR DESCRIPTION
IT8xxx2 has an FPU but cannot use -march=rv32imafc: add multilib support
for -march=rv32iafc so the FPU can be used on IT8xxx2. This adds -iafc
as a multilib alias for -iac so doesn't build any additional libraries;
it only teaches the compiler that the -iac libraries can be used for
-iafc systems.

Use of --with-multilib-generator replaces all the default multilib
targets, so the complete set of multilib options are copied from GCC's
defaults in `gcc/config/riscv/t-elf-multilib`.

Signed-off-by: Peter Marheine <pmarheine@chromium.org>