### PR TITLE
Revert "ci: Use Zephyr topic-sdk15 branch for testing"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
       zephyr-ref:
         description: 'Zephyr Ref (branch, tag, SHA, ...)'
         required: true
-        default: topic-sdk15
+        default: main
       host:
         description: 'Host'
         type: choice

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ env:
   BUG_URL: 'https://github.com/zephyrproject-rtos/sdk-ng/issues'
   BUNDLE_NAME: Zephyr SDK
   BUNDLE_PREFIX: zephyr-sdk
-  ZEPHYR_REF: topic-sdk15
+  ZEPHYR_REF: main
 
 jobs:
   # Setup


### PR DESCRIPTION
This reverts commit https://github.com/zephyrproject-rtos/sdk-ng/commit/589923639e51d566a333fd028c22fe67d1cdc4ea and https://github.com/zephyrproject-rtos/sdk-ng/commit/cd04a0ba13b90f891557e68b64a45b3c78f2f9aa.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>