### PR TITLE
cmake: support loading of host-tool through COMPONENTS

### DIFF
--- a/cmake/FindZephyr-sdk_HostTools.cmake
+++ b/cmake/FindZephyr-sdk_HostTools.cmake
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2022, Nordic Semiconductor ASA
+
+# FindZephyr-sdk_HostTools module for locating HostTools components in Zephyr SDK.
+#
+# The module defines the following variables:
+#
+# 'HOST_TOOLS_HOME'
+# Path to host tools home if installed.
+# Set to 'HOST_TOOLS_HOME-NOTFOUND' if not installed.
+#
+# 'Zephyr-sdk_HostTools_FOUND', 'ZEPHYR-SDK_HOSTTOOLS_FOUND'
+#  True if the host tools are found.
+
+cmake_host_system_information(RESULT TOOLCHAIN_ARCH QUERY OS_PLATFORM)
+set(HOST_TOOLS_HOME ${ZEPHYR_SDK_INSTALL_DIR}/sysroots/${TOOLCHAIN_ARCH}-pokysdk-linux)
+if(NOT EXISTS ${HOST_TOOLS_HOME})
+  set(HOST_TOOLS_HOME_MISSING ${HOST_TOOLS_HOME})
+  set(HOST_TOOLS_HOME HOST_TOOLS_HOME-NOTFOUND)
+endif()
+
+find_package_handle_standard_args(Zephyr-sdk_HostTools
+                                  REQUIRED_VARS HOST_TOOLS_HOME ${HOST_TOOLS_HOME_MISSING}
+                                  VERSION_VAR   Zephyr-sdk_VERSION
+)
+
+if(Zephyr-sdk_HostTools_FOUND)
+  # Path used for searching by the find_*() functions, with appropriate
+  # suffixes added. Ensures that the SDK's host tools will be found when
+  # we call, e.g. find_program(QEMU qemu-system-x86)
+  list(APPEND CMAKE_PREFIX_PATH ${HOST_TOOLS_HOME}/usr)
+
+  # TODO: Use find_* somehow for these as well?
+  set_ifndef(QEMU_BIOS            ${HOST_TOOLS_HOME}/usr/share/qemu)
+  set_ifndef(OPENOCD_DEFAULT_PATH ${HOST_TOOLS_HOME}/usr/share/openocd/scripts)
+endif()

--- a/cmake/Zephyr-sdkConfig.cmake
+++ b/cmake/Zephyr-sdkConfig.cmake
@@ -13,6 +13,14 @@ get_filename_component(ZEPHYR_SDK_INSTALL_DIR ${CMAKE_CURRENT_LIST_DIR}/.. ABSOL
 set(ZEPHYR_SDK_INSTALL_DIR ${ZEPHYR_SDK_INSTALL_DIR})
 set(ZEPHYR_TOOLCHAIN_VARIANT zephyr)
 
+# Load additional components. Only components inside Zephyr SDK are allowed.
+set(CURRENT_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+foreach(component ${Zephyr-sdk_FIND_COMPONENTS})
+  find_package(Zephyr-sdk_${component})
+endforeach()
+set(CMAKE_MODULE_PATH ${CURRENT_CMAKE_MODULE_PATH})
+
 # Those are CMake package parameters.
 set(Zephyr-sdk_FOUND True)
 set(Zephyr-sdk_DIR   ${ZEPHYR_SDK_INSTALL_DIR})

--- a/cmake/zephyr/host-tools.cmake
+++ b/cmake/zephyr/host-tools.cmake
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# This file is kept for backward compatibility with Zephyr <v3.2.0
+
 cmake_host_system_information(RESULT TOOLCHAIN_ARCH QUERY OS_PLATFORM)
 set(HOST_TOOLS_HOME ${ZEPHYR_SDK_INSTALL_DIR}/sysroots/${TOOLCHAIN_ARCH}-pokysdk-linux)
 


### PR DESCRIPTION
Support loading of host tools as part of Zephyr-sdk.

This allows users of Zephyr SDK to do:
`find_package(Zephyr-sdk COMPONENTS HostTools)`
instead of having to do something like:
`find_package(Zephyr-sdk COMPONENTS HostTools)`
`include(${ZEPHYR_SDK}/cmake/zephyr/host-tools.cmake)`

it further improve loading of host-tools as those are only loaded if
installed.
Because host tools are now loaded as a find module, then generic CMake
reporting regarding module loading is used.

This allows us to cleanup Zephyr CMake code as well as place the
responsibility of checking and loading of host tools into Zephyr SDK.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>