### PR TITLE
cmake: Update Kconfig symbol name for 0.15

### DIFF
--- a/cmake/zephyr/Kconfig
+++ b/cmake/zephyr/Kconfig
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-config TOOLCHAIN_ZEPHYR_0_14
+config TOOLCHAIN_ZEPHYR_0_15
 	def_bool y
 	select HAS_NEWLIB_LIBC_NANO if (ARC || (ARM && !ARM64) || RISCV)
 


### PR DESCRIPTION
This commit updates the Kconfig symbol name to reflect the current version of Zephyr SDK (the 0.15.0 release forgot to do it).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>