### PR TITLE
openocd: Pull in sleeping target flash failure fix

### DIFF
--- a/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_git.bb
+++ b/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_git.bb
@@ -6,7 +6,7 @@ RDEPENDS_${PN} = "libusb1 hidapi"
 SRC_URI = " \
 	git://github.com/zephyrproject-rtos/openocd.git;protocol=https;nobranch=1 \
 	"
-SRCREV = "42b6471c1f6c3236ec762e9a4fde62c84ab6861d"
+SRCREV = "c5c47943dbd036079d96fe49ea9092f78abec427"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This commit pulls in the fix for the OpenOCD failing to flash a target when the target is in sleep state.

Note that this is only a workaround until the Zephyr-side OpenOCD configurations are updated to fundamentally fix this issue -- refer to the linked OpenOCD commit message for more details.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

OpenOCD PR: https://github.com/zephyrproject-rtos/openocd/pull/52