### PR TITLE
ci: Use larger runner for Windows testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1240,10 +1240,10 @@ jobs:
       fail-fast: false
       matrix:
         testenv: ${{ fromJSON(needs.setup.outputs.testenvs) }}
-        subset: [ 1, 2, 3, 4, 5 ]
+        subset: [ 1, 2 ]
 
     env:
-      SUBSET_COUNT: 5
+      SUBSET_COUNT: 2
       PYTHON_DEPS: https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/main/scripts/requirements.txt
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,7 @@ jobs:
         if [ "${build_host_windows_x86_64}" == "y" ]; then
           MATRIX_TESTENVS+='{
               "name": "windows-2019-x86_64",
-              "runner": "windows-2019",
+              "runner": "windows-2019-8c",
               "container": "",
               "bundle-host": "windows-x86_64",
               "bundle-archive": "zip"


### PR DESCRIPTION
This commit updates the CI workflow to use a larger 8-core runner for
testing Zephyr SDK distribution bundle on Windows.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>