### PR TITLE
scripts: Use toolchain list from distribution bundle build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1139,6 +1139,9 @@ jobs:
         # Stage version file
         echo "${VERSION}" > sdk_version
 
+        # Stage toolchain list file
+        echo '${{ needs.setup.outputs.targets }}' | jq -cr '.[]' > sdk_toolchains
+
         # Stage CMake package
         ## Verify CMake package archive checksum
         pushd ${ARTIFACT_ROOT}/cmake_${HOST}

--- a/scripts/template_setup_posix
+++ b/scripts/template_setup_posix
@@ -116,26 +116,7 @@ user_prompt()
 pushd "$(dirname "${BASH_SOURCE[0]}")"
 
 # Initialise toolchain list
-toolchains=(
-  "aarch64-zephyr-elf"
-  "arc64-zephyr-elf"
-  "arc-zephyr-elf"
-  "arm-zephyr-eabi"
-  "mips-zephyr-elf"
-  "nios2-zephyr-elf"
-  "riscv64-zephyr-elf"
-  "sparc-zephyr-elf"
-  "x86_64-zephyr-elf"
-  "xtensa-espressif_esp32_zephyr-elf"
-  "xtensa-espressif_esp32s2_zephyr-elf"
-  "xtensa-intel_apl_adsp_zephyr-elf"
-  "xtensa-intel_bdw_adsp_zephyr-elf"
-  "xtensa-intel_byt_adsp_zephyr-elf"
-  "xtensa-intel_s1000_zephyr-elf"
-  "xtensa-nxp_imx_adsp_zephyr-elf"
-  "xtensa-nxp_imx8m_adsp_zephyr-elf"
-  "xtensa-sample_controller_zephyr-elf"
-  )
+toolchains=$(<sdk_toolchains)
 
 # Initialise list of toolchains to install
 inst_toolchains=()

--- a/scripts/template_setup_win
+++ b/scripts/template_setup_win
@@ -25,24 +25,9 @@ exit /b 0
 
 REM # Initialise toolchain list
 set TOOLCHAINS=
-set TOOLCHAINS=%TOOLCHAINS% aarch64-zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% arc64-zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% arc-zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% arm-zephyr-eabi
-set TOOLCHAINS=%TOOLCHAINS% mips-zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% nios2-zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% riscv64-zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% sparc-zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% x86_64-zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% xtensa-espressif_esp32_zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% xtensa-espressif_esp32s2_zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% xtensa-intel_apl_adsp_zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% xtensa-intel_bdw_adsp_zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% xtensa-intel_byt_adsp_zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% xtensa-intel_s1000_zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% xtensa-nxp_imx_adsp_zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% xtensa-nxp_imx8m_adsp_zephyr-elf
-set TOOLCHAINS=%TOOLCHAINS% xtensa-sample_controller_zephyr-elf
+for /f %%t in (sdk_toolchains) do (
+  set TOOLCHAINS=%TOOLCHAINS% %%t
+)
 
 REM Initialise list of toolchains to install
 set INST_TOOLCHAINS=


### PR DESCRIPTION
This commit updates the CI workflow to output a toolchain list file (`sdk_toolchains`) while building a distribution bundle and updates the distribution bundle setup scripts to use it instead of a hard-coded one.

This allows partial distribution bundle builds without all the supported toolchains to be properly handled by the distribution bundle setup script.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Closes https://github.com/zephyrproject-rtos/sdk-ng/issues/516