### PR TITLE
ci: Use LZMA compression for build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
               "name": "windows-x86_64",
               "runner": "zephyr_runner",
               "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.2.3",
-              "archive": "zip"
+              "archive": "7z"
             },'
         fi
 
@@ -305,7 +305,7 @@ jobs:
               "runner": "windows-2019-8c",
               "container": "",
               "bundle-host": "windows-x86_64",
-              "bundle-archive": "zip"
+              "bundle-archive": "7z"
             },'
         fi
 
@@ -409,7 +409,7 @@ jobs:
         sudo apt-get install -y autoconf automake bison flex gettext \
                                 help2man libboost-dev libboost-regex-dev \
                                 libncurses5-dev libtool-bin libtool-doc \
-                                pkg-config texinfo zip
+                                pkg-config texinfo p7zip
 
         # Install dependencies for cross compilation
         if [ "${{ matrix.host.name }}" == "linux-aarch64" ]; then
@@ -754,10 +754,9 @@ jobs:
           XZ_OPT="-T0" \
           ${TAR} -Jcvf ${ARCHIVE_FILE} \
                  --owner=0 --group=0 -C ${OUTPUT_BASE}/${OUTPUT_DIR} ${{ matrix.target }}
-        elif [ "${{ matrix.host.archive }}" == "zip" ]; then
+        elif [ "${{ matrix.host.archive }}" == "7z" ]; then
           pushd ${OUTPUT_BASE}/${OUTPUT_DIR}
-          zip -r ${GITHUB_WORKSPACE}/${ARCHIVE_FILE} \
-                 ${{ matrix.target }}
+          7z a -t7z -l ${GITHUB_WORKSPACE}/${ARCHIVE_FILE} ${{ matrix.target }}
           popd
         fi
 
@@ -981,7 +980,7 @@ jobs:
 
         # Install common dependencies
         sudo apt-get update
-        sudo apt-get install -y zip
+        sudo apt-get install -y p7zip
 
         # Set environment variables
         echo "TAR=tar" >> $GITHUB_ENV
@@ -1026,9 +1025,8 @@ jobs:
           XZ_OPT="-T0" \
           ${TAR} -Jcvf ${ARCHIVE_FILE} --owner=0 --group=0 \
                  -C . cmake
-        elif [ "${{ matrix.host.archive }}" == "zip" ]; then
-          zip -r ${ARCHIVE_FILE} \
-                 cmake
+        elif [ "${{ matrix.host.archive }}" == "7z" ]; then
+          7z a -t7z -l ${ARCHIVE_FILE} cmake
         fi
 
         # Compute checksum
@@ -1071,7 +1069,7 @@ jobs:
 
         # Install common dependencies
         sudo apt-get update
-        sudo apt-get install -y jq zip
+        sudo apt-get install -y jq p7zip
 
         # Set environment variables
         echo "TAR=tar" >> $GITHUB_ENV
@@ -1131,8 +1129,8 @@ jobs:
 
         if [ "${{ matrix.host.archive }}" == "tar.xz" ]; then
           EXTRACT="${TAR} -Jxvf"
-        elif [ "${{ matrix.host.archive }}" == "zip" ]; then
-          EXTRACT="unzip"
+        elif [ "${{ matrix.host.archive }}" == "7z" ]; then
+          EXTRACT="7z x -o."
         fi
 
         # Create bundle directory
@@ -1185,8 +1183,8 @@ jobs:
           XZ_OPT="-T0" \
           ${TAR} -Jcvf ${ARCHIVE_NAME}_minimal.${EXT} --owner=0 --group=0 \
                  -C . ${ARCHIVE_DIR}
-        elif [ "${{ matrix.host.archive }}" == "zip" ]; then
-          zip -r ${ARCHIVE_NAME}_minimal.${EXT} ${ARCHIVE_DIR}
+        elif [ "${{ matrix.host.archive }}" == "7z" ]; then
+          7z a -t7z -l ${ARCHIVE_NAME}_minimal.${EXT} ${ARCHIVE_DIR}
         fi
 
         # Stage toolchains
@@ -1215,8 +1213,8 @@ jobs:
           XZ_OPT="-T0" \
           ${TAR} -Jcvf ${ARCHIVE_NAME}.${EXT} --owner=0 --group=0 \
                  -C . ${ARCHIVE_DIR}
-        elif [ "${{ matrix.host.archive }}" == "zip" ]; then
-          zip -r ${ARCHIVE_NAME}.${EXT} ${ARCHIVE_DIR}
+        elif [ "${{ matrix.host.archive }}" == "7z" ]; then
+          7z a -t7z -l ${ARCHIVE_NAME}.${EXT} ${ARCHIVE_DIR}
         fi
 
         # Compute checksum
@@ -1323,7 +1321,7 @@ jobs:
         shopt -u dotglob
 
         # Install required system packages
-        choco install ccache dtc-msys2 gperf jq ninja wget unzip
+        choco install ccache dtc-msys2 gperf jq ninja wget 7zip
 
         # Upgrade pip
         python3 -m pip install --upgrade pip
@@ -1380,8 +1378,8 @@ jobs:
         BUNDLE_FILE=${BUNDLE_NAME}.${{ matrix.testenv.bundle-archive }}
         if [ "${{ matrix.testenv.bundle-archive }}" == "tar.xz" ]; then
           ${TAR} -Jxvf ${ARTIFACT_ROOT}/${BUNDLE_FILE} -C tools
-        elif [ "${{ matrix.testenv.bundle-archive }}" == "zip" ]; then
-          unzip ${ARTIFACT_ROOT}/${BUNDLE_FILE} -d tools
+        elif [ "${{ matrix.testenv.bundle-archive }}" == "7z" ]; then
+          7z x -otools ${ARTIFACT_ROOT}/${BUNDLE_FILE}
         fi
 
         # Run setup script

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
               "name": "linux-x86_64",
               "runner": "zephyr_runner",
               "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.2.3",
-              "archive": "tar.gz"
+              "archive": "tar.xz"
             },'
         fi
 
@@ -221,7 +221,7 @@ jobs:
               "name": "linux-aarch64",
               "runner": "zephyr_runner",
               "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.2.3",
-              "archive": "tar.gz"
+              "archive": "tar.xz"
             },'
         fi
 
@@ -230,7 +230,7 @@ jobs:
               "name": "macos-x86_64",
               "runner": "zephyr_runner-macos-x86_64",
               "container": "",
-              "archive": "tar.gz"
+              "archive": "tar.xz"
             },'
         fi
 
@@ -239,7 +239,7 @@ jobs:
               "name": "macos-aarch64",
               "runner": "zephyr_runner-macos-x86_64",
               "container": "",
-              "archive": "tar.gz"
+              "archive": "tar.xz"
             },'
         fi
 
@@ -285,7 +285,7 @@ jobs:
               "runner": "ubuntu-20.04",
               "container": "",
               "bundle-host": "linux-x86_64",
-              "bundle-archive": "tar.gz"
+              "bundle-archive": "tar.xz"
             },'
         fi
 
@@ -295,7 +295,7 @@ jobs:
               "runner": "macos-11",
               "container": "",
               "bundle-host": "macos-x86_64",
-              "bundle-archive": "tar.gz"
+              "bundle-archive": "tar.xz"
             },'
         fi
 
@@ -750,8 +750,9 @@ jobs:
         ARCHIVE_NAME=toolchain_${{ matrix.host.name }}_${{ matrix.target }}
         ARCHIVE_FILE=${ARCHIVE_NAME}.${{ matrix.host.archive }}
 
-        if [ "${{ matrix.host.archive }}" == "tar.gz" ]; then
-          ${TAR} -zcvf ${ARCHIVE_FILE} \
+        if [ "${{ matrix.host.archive }}" == "tar.xz" ]; then
+          XZ_OPT="-T0" \
+          ${TAR} -Jcvf ${ARCHIVE_FILE} \
                  --owner=0 --group=0 -C ${OUTPUT_BASE}/${OUTPUT_DIR} ${{ matrix.target }}
         elif [ "${{ matrix.host.archive }}" == "zip" ]; then
           pushd ${OUTPUT_BASE}/${OUTPUT_DIR}
@@ -914,9 +915,10 @@ jobs:
         ARTIFACT=${ARTIFACT[0]}
         ARTIFACT=$(basename ${ARTIFACT})
         ARCHIVE_NAME=hosttools_${{ matrix.host.name }}
-        ARCHIVE_FILE=hosttools_${{ matrix.host.name }}.tar.gz
+        ARCHIVE_FILE=hosttools_${{ matrix.host.name }}.tar.xz
 
-        ${TAR} -zcvf ${ARCHIVE_FILE} --owner=0 --group=0 \
+        XZ_OPT="-T0" \
+        ${TAR} -Jcvf ${ARCHIVE_FILE} --owner=0 --group=0 \
                -C ${ARTIFACT_ROOT} ${ARTIFACT}
 
         # Compute checksum
@@ -1020,8 +1022,9 @@ jobs:
         ARCHIVE_NAME=cmake_${{ matrix.host.name }}
         ARCHIVE_FILE=${ARCHIVE_NAME}.${{ matrix.host.archive }}
 
-        if [ "${{ matrix.host.archive }}" == "tar.gz" ]; then
-          ${TAR} -zcvf ${ARCHIVE_FILE} --owner=0 --group=0 \
+        if [ "${{ matrix.host.archive }}" == "tar.xz" ]; then
+          XZ_OPT="-T0" \
+          ${TAR} -Jcvf ${ARCHIVE_FILE} --owner=0 --group=0 \
                  -C . cmake
         elif [ "${{ matrix.host.archive }}" == "zip" ]; then
           zip -r ${ARCHIVE_FILE} \
@@ -1126,8 +1129,8 @@ jobs:
 
         echo "BUNDLE_ARCHIVE_NAME=${ARCHIVE_NAME}" >> $GITHUB_ENV
 
-        if [ "${{ matrix.host.archive }}" == "tar.gz" ]; then
-          EXTRACT="${TAR} -zxvf"
+        if [ "${{ matrix.host.archive }}" == "tar.xz" ]; then
+          EXTRACT="${TAR} -Jxvf"
         elif [ "${{ matrix.host.archive }}" == "zip" ]; then
           EXTRACT="unzip"
         fi
@@ -1178,8 +1181,9 @@ jobs:
         popd
 
         # Create minimal (without toolchains) distribution bundle archive
-        if [ "${{ matrix.host.archive }}" == "tar.gz" ]; then
-          ${TAR} -zcvf ${ARCHIVE_NAME}_minimal.${EXT} --owner=0 --group=0 \
+        if [ "${{ matrix.host.archive }}" == "tar.xz" ]; then
+          XZ_OPT="-T0" \
+          ${TAR} -Jcvf ${ARCHIVE_NAME}_minimal.${EXT} --owner=0 --group=0 \
                  -C . ${ARCHIVE_DIR}
         elif [ "${{ matrix.host.archive }}" == "zip" ]; then
           zip -r ${ARCHIVE_NAME}_minimal.${EXT} ${ARCHIVE_DIR}
@@ -1207,8 +1211,9 @@ jobs:
         popd
 
         # Create full distribution bundle archive
-        if [ "${{ matrix.host.archive }}" == "tar.gz" ]; then
-          ${TAR} -zcvf ${ARCHIVE_NAME}.${EXT} --owner=0 --group=0 \
+        if [ "${{ matrix.host.archive }}" == "tar.xz" ]; then
+          XZ_OPT="-T0" \
+          ${TAR} -Jcvf ${ARCHIVE_NAME}.${EXT} --owner=0 --group=0 \
                  -C . ${ARCHIVE_DIR}
         elif [ "${{ matrix.host.archive }}" == "zip" ]; then
           zip -r ${ARCHIVE_NAME}.${EXT} ${ARCHIVE_DIR}
@@ -1373,8 +1378,8 @@ jobs:
 
         # Extract distribution bundle archive
         BUNDLE_FILE=${BUNDLE_NAME}.${{ matrix.testenv.bundle-archive }}
-        if [ "${{ matrix.testenv.bundle-archive }}" == "tar.gz" ]; then
-          ${TAR} -zxvf ${ARTIFACT_ROOT}/${BUNDLE_FILE} -C tools
+        if [ "${{ matrix.testenv.bundle-archive }}" == "tar.xz" ]; then
+          ${TAR} -Jxvf ${ARTIFACT_ROOT}/${BUNDLE_FILE} -C tools
         elif [ "${{ matrix.testenv.bundle-archive }}" == "zip" ]; then
           unzip ${ARTIFACT_ROOT}/${BUNDLE_FILE} -d tools
         fi

--- a/scripts/template_setup_posix
+++ b/scripts/template_setup_posix
@@ -185,7 +185,7 @@ esac
 
 # Resolve release download base URI
 dl_rel_base="https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${version}"
-dl_toolchain_filename='toolchain_${host}_${toolchain}.tar.gz'
+dl_toolchain_filename='toolchain_${host}_${toolchain}.tar.xz'
 
 # Print banner
 echo "Zephyr SDK ${version} Setup"

--- a/scripts/template_setup_win
+++ b/scripts/template_setup_win
@@ -37,7 +37,7 @@ set /p VERSION=<sdk_version
 
 REM # Resolve release download base URI
 set DL_REL_BASE=https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v%VERSION%
-set DL_TOOLCHAIN_FILENAME=toolchain_windows-x86_64_%%t.zip
+set DL_TOOLCHAIN_FILENAME=toolchain_windows-x86_64_%%t.7z
 
 REM # Print banner
 echo Zephyr SDK %VERSION% Setup
@@ -54,7 +54,7 @@ call :check_command cmake 90
 if [%ERRORLEVEL%] neq [0] goto end
 call :check_command wget 91
 if [%ERRORLEVEL%] neq [0] goto end
-call :check_command unzip 92
+call :check_command 7z 92
 if [%ERRORLEVEL%] neq [0] goto end
 
 REM # Enter interactive mode if enabled
@@ -152,7 +152,7 @@ for %%t in (%INST_TOOLCHAINS%) do (
     )
 
     REM # Extract archive
-    unzip -q !TOOLCHAIN_FILENAME!
+    7z x -o. !TOOLCHAIN_FILENAME!
     if [!ERRORLEVEL!] neq [0] (
       echo ERROR: Toolchain archive extraction failed
       set EXITCODE=21


### PR DESCRIPTION
This series updates the CI workflow to output `.tar.xz` (Linux and macOS) and `.7z` (Windows) build artifacts to reduce the overall artifact sizes.

Closes #567