### PR TITLE
scripts: template_setup_win: Fix toolchain list loading

### DIFF
--- a/scripts/template_setup_win
+++ b/scripts/template_setup_win
@@ -26,7 +26,7 @@ exit /b 0
 REM # Initialise toolchain list
 set TOOLCHAINS=
 for /f %%t in (sdk_toolchains) do (
-  set TOOLCHAINS=%TOOLCHAINS% %%t
+  set TOOLCHAINS=!TOOLCHAINS! %%t
 )
 
 REM Initialise list of toolchains to install


### PR DESCRIPTION
`!` must be used instead of `%` inside a loop when referencing a variable that is changed within the loop.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>