### PR TITLE
ci: Shorten distribution bundle path on Windows for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1383,8 +1383,14 @@ jobs:
         pushd ${GITHUB_WORKSPACE}/tools/${BUNDLE_DIR}
 
         if [ "${{ runner.os }}" == "Windows" ]; then
+          # Shorten distribution bundle path on Windows
+          subst s: ${PWD}
+          pushd /s
           # NOTE: Escape forward slashes because MinGW (bash)
-          ./setup.cmd //t all //h //c
+          # NOTE: A full path (using PWD) must be specified to ensure that the
+          #       setup script is launched from the shortened path.
+          ${PWD}/setup.cmd //t all //h //c
+          popd
         else
           ./setup.sh -t all -h -c
         fi


### PR DESCRIPTION
This commit updates the CI workflow to shorten the distribution bundle path on Windows for testing because the full path can be too long for some architectures and may cause build failures.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>