### PR TITLE
ci: Allow running CI workflow in topic branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,13 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+    - main
+    - topic-*
   pull_request_target:
-    branches: [ main ]
+    branches:
+    - main
+    - topic-*
   workflow_call:
     secrets:
       AWS_CACHE_SDK_ACCESS_KEY_ID:


### PR DESCRIPTION
This commit updates the CI workflow to allow running the workflow in the branches prefixed with `topic-` (i.e. topic branches).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>