### PR TITLE
scripts: template_setup_posix: Fix Linux OS type detection

### DIFF
--- a/scripts/template_setup_posix
+++ b/scripts/template_setup_posix
@@ -166,7 +166,7 @@ version=$(<sdk_version)
 
 # Resolve host type
 case ${OSTYPE} in
-  linux-gnu*)
+  linux*)
     host="linux-${HOSTTYPE}"
     ;;
   darwin*)


### PR DESCRIPTION
This commit updates the POSIX setup script to use `linux*` instead of `linux-gnu*` to detect the Linux host OS type because some distros may omit the `-gnu` part.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>