### PR TITLE
meta-zephyr-sdk: Downgrade glibc to 2.27

### DIFF
--- a/meta-zephyr-sdk/scripts/meta-zephyr-sdk-clone.sh
+++ b/meta-zephyr-sdk/scripts/meta-zephyr-sdk-clone.sh
@@ -18,7 +18,7 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #
 
-POKY_KNOWN_COMMIT=${POKY_COMMIT:-"08665a81dcd41069eed1468f1587abe6b5893471"}
+POKY_KNOWN_COMMIT=${POKY_COMMIT:-"528279328f390ea2db3034cebc37306816abee8d"}
 META_ZEPHYR_SDK_SOURCE=${SDK_SOURCE:-"meta-zephyr-sdk"}
 META_POKY_SOURCE=${POKY_SOURCE:-"poky"}
 META_ZEPHYR_SDK_SOURCE=$(readlink -f $META_ZEPHYR_SDK_SOURCE)
@@ -30,7 +30,7 @@ if [ ! -d $META_ZEPHYR_SDK_SOURCE ] ; then
 fi
 
 if [ ! -d $META_POKY_SOURCE ] ; then
-	git clone http://git.yoctoproject.org/git/poky
+	git clone https://github.com/zephyrproject-rtos/poky.git
 	META_POKY_SOURCE=$(readlink -f "poky")
 fi
 


### PR DESCRIPTION
This commit pulls in the Poky commit that downgrades the glibc version to 2.27 in order to ensure that the nativesdk binaries are compatible with older Linux distros.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

---

Poky commit https://github.com/zephyrproject-rtos/poky/commit/18a79ded82711695fc91711029529d7161a13610

Fixes #584