### PR TITLE
template_setup_posix: Suppress Yocto nativesdk installer messages

### DIFF
--- a/scripts/template_setup_posix
+++ b/scripts/template_setup_posix
@@ -236,7 +236,7 @@ if [ "${do_hosttools}" = "y" ]; then
   echo "Installing host tools ..."
   case ${host} in
     linux-*)
-      ./zephyr-sdk-${HOSTTYPE}-hosttools-standalone-0.9.sh -y -d .
+      ./zephyr-sdk-${HOSTTYPE}-hosttools-standalone-0.9.sh -y -d . &> /dev/null
       assert_rc "ERROR: Host tools installation failed" 30
       ;;
     macos-*)


### PR DESCRIPTION
The Linux host tools for Zephyr SDK are packaged using the Yocto nativesdk recipe and its installer may print out the messages that can be potentially misleading to the Zephyr SDK users, who do not need to understand the internals of the Zephyr SDK host tools integration.

This commit updates the setup script to suppress any console outputs from the Yocto nativesdk installer script.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>