### PR TITLE
template_setup_posix: Fix command line toolchain flag handling

### DIFF
--- a/scripts/template_setup_posix
+++ b/scripts/template_setup_posix
@@ -117,6 +117,7 @@ pushd "$(dirname "${BASH_SOURCE[0]}")"
 
 # Initialise toolchain list
 toolchains=$(<sdk_toolchains)
+toolchains=("${toolchains[@]//$'\n'/ }")
 
 # Initialise list of toolchains to install
 inst_toolchains=()


### PR DESCRIPTION
The commit 05f60473445299a9650048e876d8f84838b19359 moved the toolchain list from the setup script itself to an external file (`sdk_toolchains`).

This change also introduced a delimiter change from 'SPACE' to 'LF' that broke the regular expression used by the toolchain (`-t`) flag handler, which assumes the 'SPACE' delimiter.

This commit reworks the setup script to convert the 'LF' delimiter to 'SPACE' after loading the toolchain list from `sdk_toolchains` to fix this issue.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>