### PR TITLE
Various CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,14 +92,14 @@ jobs:
     steps:
     - name: Check out source code
       if: ${{ github.event_name != 'pull_request_target' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
         persist-credentials: false
 
     - name: Check out source code (pull request)
       if: ${{ github.event_name == 'pull_request_target' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -111,7 +111,7 @@ jobs:
         echo "${VERSION:1}" > version
 
     - name: Upload version file
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: version
         path: version
@@ -516,14 +516,14 @@ jobs:
 
     - name: Check out source code
       if: ${{ github.event_name != 'pull_request_target' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
         persist-credentials: false
 
     - name: Check out source code (pull request)
       if: ${{ github.event_name == 'pull_request_target' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         submodules: recursive
@@ -565,13 +565,13 @@ jobs:
         ${CT_NG} version
 
     - name: Download version information
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: version
         path: ${{ runner.temp }}
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-access-key-id: ${{ secrets.AWS_CACHE_SDK_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_CACHE_SDK_SECRET_ACCESS_KEY }}
@@ -789,13 +789,13 @@ jobs:
 
     - name: Upload toolchain build log
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: log_${{ matrix.host.name }}_${{ matrix.target }}
         path: ${{ matrix.target }}.log
 
     - name: Upload toolchain build artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: toolchain_${{ matrix.host.name }}_${{ matrix.target }}
         path: |
@@ -852,21 +852,21 @@ jobs:
 
     - name: Check out source code
       if: ${{ github.event_name != 'pull_request_target' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
         persist-credentials: false
 
     - name: Check out source code (pull request)
       if: ${{ github.event_name == 'pull_request_target' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         submodules: recursive
         persist-credentials: false
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-access-key-id: ${{ secrets.AWS_CACHE_SDK_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_CACHE_SDK_SECRET_ACCESS_KEY }}
@@ -945,7 +945,7 @@ jobs:
 
     - name: Upload toolchain build artifact
       if: startsWith(matrix.host.name, 'linux-') # FIXME: Do for all
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: hosttools_${{ matrix.host.name }}
         path: |
@@ -1007,13 +1007,13 @@ jobs:
 
     - name: Check out source code
       if: ${{ github.event_name != 'pull_request_target' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
 
     - name: Check out source code (pull request)
       if: ${{ github.event_name == 'pull_request_target' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
@@ -1037,7 +1037,7 @@ jobs:
         sha256sum ${ARCHIVE_FILE} > sha256.sum
 
     - name: Upload CMake package build artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: cmake_${{ matrix.host.name }}
         path: |
@@ -1096,21 +1096,21 @@ jobs:
 
     - name: Check out source code
       if: ${{ github.event_name != 'pull_request_target' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: repository
         persist-credentials: false
 
     - name: Check out source code (pull request)
       if: ${{ github.event_name == 'pull_request_target' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         path: repository
         persist-credentials: false
 
     - name: Download artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         # NOTE: This downloads all build artifacts, including the toolchains and host tools for
         #       the irrelevant hosts, because the download-artifact action does not support
@@ -1223,7 +1223,7 @@ jobs:
         sha256sum ${ARCHIVE_NAME}.${EXT} ${ARCHIVE_NAME}_minimal.${EXT} > sha256.sum
 
     - name: Upload distribution bundle
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ env.BUNDLE_ARCHIVE_NAME }}
         path: |
@@ -1256,7 +1256,7 @@ jobs:
 
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         # Force Python 3.10 because the twister is not compatible with a Python
         # version lower than 3.8 on Windows.
@@ -1340,7 +1340,7 @@ jobs:
         echo "ARTIFACT_ROOT=${GITHUB_WORKSPACE}/artifacts" >> $GITHUB_ENV
 
     - name: Download version information
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: version
         path: artifacts
@@ -1359,7 +1359,7 @@ jobs:
         echo "BUNDLE_DIR=${BUNDLE_DIR}" >> $GITHUB_ENV
 
     - name: Download distribution bundle
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ${{ env.BUNDLE_NAME }}
         path: artifacts
@@ -1534,7 +1534,7 @@ jobs:
 
     - name: Publish test results
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: test_${{ matrix.testenv.name }}_${{ matrix.subset }}
         if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
         if [ "${build_host_linux_x86_64}" == "y" ]; then
           MATRIX_HOSTS+='{
               "name": "linux-x86_64",
-              "runner": "zephyr_runner",
+              "runner": "zephyr-runner-linux-x64-4xlarge",
               "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.2.3",
               "archive": "tar.gz"
             },'
@@ -223,7 +223,7 @@ jobs:
         if [ "${build_host_linux_aarch64}" == "y" ]; then
           MATRIX_HOSTS+='{
               "name": "linux-aarch64",
-              "runner": "zephyr_runner",
+              "runner": "zephyr-runner-linux-x64-4xlarge",
               "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.2.3",
               "archive": "tar.gz"
             },'
@@ -250,7 +250,7 @@ jobs:
         if [ "${build_host_windows_x86_64}" == "y" ]; then
           MATRIX_HOSTS+='{
               "name": "windows-x86_64",
-              "runner": "zephyr_runner",
+              "runner": "zephyr-runner-linux-x64-4xlarge",
               "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.2.3",
               "archive": "zip"
             },'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,10 +332,10 @@ jobs:
         MATRIX_TESTENVS=$(echo "${MATRIX_TESTENVS}" | sed -zr 's/,([^,]*$)/\1/')
 
         # Output matrix variables
-        echo "::set-output name=hosts::${MATRIX_HOSTS}"
-        echo "::set-output name=targets::${MATRIX_TARGETS}"
-        echo "::set-output name=testenvs::${MATRIX_TESTENVS}"
-        echo "::set-output name=debug::${MATRIX_DEBUG}"
+        echo "hosts=${MATRIX_HOSTS}" >> $GITHUB_OUTPUT
+        echo "targets=${MATRIX_TARGETS}" >> $GITHUB_OUTPUT
+        echo "testenvs=${MATRIX_TESTENVS}" >> $GITHUB_OUTPUT
+        echo "debug=${MATRIX_DEBUG}" >> $GITHUB_OUTPUT
 
         # Prepare configuration report
         CONFIG_REPORT=${RUNNER_TEMP}/config-report.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         rm -rf ${GITHUB_WORKSPACE}/*
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         path: artifacts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
   release:
     name: Release
     needs: [ ci ]
-    runs-on: zephyr_runner
+    runs-on: zephyr-runner-linux-x64-4xlarge
 
     steps:
     - name: Set up build environment


### PR DESCRIPTION
This series includes various CI updates including the transition to the new Kubernetes-based zephyr-runner.

* ci: Update actions 
* ci: Convert deprecated 'set-output' command usage
* ci: Use zephyr-runner