### PR TITLE
ci: Use AArch64 zephyr-runner to natively build and test AArch64 Linux and macOS toolchains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,16 @@ jobs:
             },'
         fi
 
+        if [ "${build_host_macos_aarch64}" == "y" ]; then
+          MATRIX_TESTENVS+='{
+              "name": "macos-11-aarch64",
+              "runner": "zephyr-runner-macos-arm64-2xlarge",
+              "container": "",
+              "bundle-host": "macos-aarch64",
+              "bundle-archive": "tar.xz"
+            },'
+        fi
+
         if [ "${build_host_windows_x86_64}" == "y" ]; then
           MATRIX_TESTENVS+='{
               "name": "windows-2019-x86_64",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
         if [ "${build_host_linux_aarch64}" == "y" ]; then
           MATRIX_HOSTS+='{
               "name": "linux-aarch64",
-              "runner": "zephyr-runner-linux-x64-4xlarge",
+              "runner": "zephyr-runner-linux-arm64-4xlarge",
               "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.2.3",
               "archive": "tar.xz"
             },'
@@ -416,12 +416,7 @@ jobs:
                                 pkg-config texinfo p7zip
 
         # Install dependencies for cross compilation
-        if [ "${{ matrix.host.name }}" == "linux-aarch64" ]; then
-          # Install aarch64-linux-gnu cross toolchain
-          sudo apt-get install -y binutils-aarch64-linux-gnu \
-                                  gcc-aarch64-linux-gnu \
-                                  g++-aarch64-linux-gnu
-        elif [ "${{ matrix.host.name }}" == "windows-x86_64" ]; then
+        if [ "${{ matrix.host.name }}" == "windows-x86_64" ]; then
           # Install MinGW-w64 cross toolchain
           sudo apt-get install -y binutils-mingw-w64 gcc-mingw-w64 \
                                   g++-mingw-w64
@@ -634,13 +629,7 @@ jobs:
         EOF
 
         # Set Canadian cross compilation configurations
-        if [ "${{ matrix.host.name }}" == "linux-aarch64" ]; then
-          # Building for linux-aarch64 on linux-x86_64
-          cat <<EOF >> .config
-        CT_CANADIAN=y
-        CT_HOST="aarch64-linux-gnu"
-        EOF
-        elif [ "${{ matrix.host.name }}" == "macos-aarch64" ]; then
+        if [ "${{ matrix.host.name }}" == "macos-aarch64" ]; then
           # Building for macos-aarch64 on macos-x86_64
           cat <<EOF >> .config
         CT_CANADIAN=y
@@ -660,18 +649,7 @@ jobs:
         CT_GDB_CROSS_PYTHON_VARIANT=y
         EOF
 
-        if [ "${{ matrix.host.name }}" == "linux-aarch64" ]; then
-          # Clone crosskit-aarch64-linux-libpython cross compilation kit
-          git clone \
-            https://github.com/stephanosio/crosskit-aarch64-linux-libpython.git \
-            ${WORKSPACE}/crosskit-aarch64-linux-libpython
-          # Use Python 3.8.0
-          export LIBPYTHON_KIT_ROOT=${WORKSPACE}/crosskit-aarch64-linux-libpython/python-3.8.0
-          # Set Python configuration resolver for GDB
-          cat <<EOF >> .config
-        CT_GDB_CROSS_PYTHON_BINARY="${LIBPYTHON_KIT_ROOT}/bin/python"
-        EOF
-        elif [ "${{ matrix.host.name }}" == "macos-aarch64" ]; then
+        if [ "${{ matrix.host.name }}" == "macos-aarch64" ]; then
           # Clone crosskit-aarch64-darwin-libpython cross compilation kit
           git clone \
             https://github.com/stephanosio/crosskit-aarch64-darwin-libpython.git \
@@ -720,10 +698,7 @@ jobs:
         popd
 
         # Resolve output directory path
-        if [ "${{ matrix.host.name }}" == "linux-aarch64" ]; then
-          OUTPUT_BASE="${WORKSPACE}/output"
-          OUTPUT_DIR="HOST-aarch64-linux-gnu"
-        elif [ "${{ matrix.host.name }}" == "macos-aarch64" ]; then
+        if [ "${{ matrix.host.name }}" == "macos-aarch64" ]; then
           OUTPUT_BASE="${WORKSPACE}/output"
           OUTPUT_DIR="HOST-aarch64-apple-darwin"
         elif [ "${{ matrix.host.name }}" == "windows-x86_64" ]; then
@@ -902,12 +877,6 @@ jobs:
 
         # Patch Poky sanity configuration to allow building as root
         sed -i '/^INHERIT/ s/./#&/' poky/meta/conf/sanity.conf
-
-        # Resolve host machine type
-        if [ "${{ matrix.host.name }}" == "linux-aarch64" ]; then
-          # Cross compiling for AArch64 host on x86-64
-          export MACHINE="aarch64"
-        fi
 
         # Build meta-zephyr-sdk
         ${POKY_BASE}/scripts/meta-zephyr-sdk-build.sh tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
           MATRIX_TESTENVS+='{
               "name": "ubuntu-20.04-x86_64",
               "runner": "zephyr-runner-linux-x64-xlarge",
-              "container": "",
+              "container": "ghcr.io/zephyrproject-rtos/ci:master",
               "bundle-host": "linux-x86_64",
               "bundle-archive": "tar.xz"
             },'
@@ -297,7 +297,7 @@ jobs:
           MATRIX_TESTENVS+='{
               "name": "ubuntu-20.04-aarch64",
               "runner": "zephyr-runner-linux-arm64-xlarge",
-              "container": "",
+              "container": "ghcr.io/zephyrproject-rtos/ci:master",
               "bundle-host": "linux-aarch64",
               "bundle-archive": "tar.xz"
             },'
@@ -1238,6 +1238,7 @@ jobs:
 
     steps:
     - name: Set up Python
+      if: ${{ runner.os != 'Linux' }}
       uses: actions/setup-python@v4
       with:
         # Force Python 3.10 because the twister is not compatible with a Python
@@ -1252,24 +1253,9 @@ jobs:
         sudo rm -rf ${GITHUB_WORKSPACE}/*
         shopt -u dotglob
 
-        # Add CMake APT repository
-        wget https://apt.kitware.com/kitware-archive.sh
-        sudo bash kitware-archive.sh
-
         # Install required system packages
         sudo apt-get update
-        sudo apt-get install -y ccache cmake device-tree-compiler dos2unix \
-                                git gperf jq ninja-build wget
-
-        # Upgrade pip
-        python3 -m pip install --upgrade pip
-
-        # Install west
-        pip3 install --user --upgrade west
-        echo 'export PATH=~/.local/bin:"$PATH"' >> ~/.bashrc
-
-        # Install required Python packages
-        pip3 install --user --upgrade -r "${{ env.PYTHON_DEPS }}"
+        sudo apt-get install -y dos2unix jq
 
         # Set environment variables
         echo "TAR=tar" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,16 @@ jobs:
             },'
         fi
 
+        if [ "${build_host_linux_aarch64}" == "y" ]; then
+          MATRIX_TESTENVS+='{
+              "name": "ubuntu-20.04-aarch64",
+              "runner": "zephyr-runner-linux-arm64-xlarge",
+              "container": "",
+              "bundle-host": "linux-aarch64",
+              "bundle-archive": "tar.xz"
+            },'
+        fi
+
         if [ "${build_host_macos_x86_64}" == "y" ]; then
           MATRIX_TESTENVS+='{
               "name": "macos-11-x86_64",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
         if [ "${build_host_linux_x86_64}" == "y" ]; then
           MATRIX_TESTENVS+='{
               "name": "ubuntu-20.04-x86_64",
-              "runner": "ubuntu-20.04",
+              "runner": "zephyr-runner-linux-x64-xlarge",
               "container": "",
               "bundle-host": "linux-x86_64",
               "bundle-archive": "tar.xz"
@@ -1242,10 +1242,14 @@ jobs:
         sudo rm -rf ${GITHUB_WORKSPACE}/*
         shopt -u dotglob
 
+        # Add CMake APT repository
+        wget https://apt.kitware.com/kitware-archive.sh
+        sudo bash kitware-archive.sh
+
         # Install required system packages
         sudo apt-get update
-        sudo apt-get install -y ccache device-tree-compiler dos2unix gperf \
-                                jq ninja-build wget
+        sudo apt-get install -y ccache cmake device-tree-compiler dos2unix \
+                                git gperf jq ninja-build wget
 
         # Upgrade pip
         python3 -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,7 @@ jobs:
         if [ "${build_host_macos_x86_64}" == "y" ]; then
           MATRIX_TESTENVS+='{
               "name": "macos-11-x86_64",
-              "runner": "macos-11",
+              "runner": "zephyr-runner-macos-arm64-2xlarge",
               "container": "",
               "bundle-host": "macos-x86_64",
               "bundle-archive": "tar.xz"
@@ -1238,7 +1238,7 @@ jobs:
 
     steps:
     - name: Set up Python
-      if: ${{ runner.os != 'Linux' }}
+      if: ${{ runner.os == 'Windows' }}
       uses: actions/setup-python@v4
       with:
         # Force Python 3.10 because the twister is not compatible with a Python
@@ -1269,8 +1269,11 @@ jobs:
         rm -rf ${GITHUB_WORKSPACE}/*
         shopt -u dotglob
 
-        # Install required system packages
-        brew install ccache coreutils dos2unix dtc gperf jq ninja wget
+        # Install required dependencies if running inside a GitHub-hosted runner
+        # (self-hosted runners are expected to provide all required dependencies)
+        if [[ "${{ matrix.host.runner }}" =~ ^macos.* ]]; then
+          brew install ccache coreutils dos2unix dtc gperf jq ninja wget
+        fi
 
         # Upgrade pip
         sudo python3 -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
         if [ "${build_host_macos_x86_64}" == "y" ]; then
           MATRIX_HOSTS+='{
               "name": "macos-x86_64",
-              "runner": "zephyr_runner-macos-x86_64",
+              "runner": "zephyr-runner-macos-arm64-2xlarge",
               "container": "",
               "archive": "tar.xz"
             },'
@@ -241,7 +241,7 @@ jobs:
         if [ "${build_host_macos_aarch64}" == "y" ]; then
           MATRIX_HOSTS+='{
               "name": "macos-aarch64",
-              "runner": "zephyr_runner-macos-x86_64",
+              "runner": "zephyr-runner-macos-arm64-2xlarge",
               "container": "",
               "archive": "tar.xz"
             },'
@@ -502,10 +502,10 @@ jobs:
         fi
 
         # Install dependencies for cross compilation
-        if [ "${{ matrix.host.name }}" == "macos-aarch64" ]; then
-          # Clone x86-AArch64 crosskit
+        if [ "${{ matrix.host.name }}" == "macos-x86_64" ]; then
+          # Clone AArch64-x86 crosskit
           git clone \
-            https://github.com/stephanosio/crosskit-aarch64-apple-darwin.git \
+            https://github.com/stephanosio/crosskit-x86_64-apple-darwin.git \
             ${WORKSPACE}/crosskit
 
           # Make crosskit available in PATH
@@ -513,7 +513,7 @@ jobs:
         fi
 
         # Make Python 3.8 available in PATH
-        echo "/usr/local/opt/python@3.8/bin" >> $GITHUB_PATH
+        echo "${HOMEBREW_PREFIX}/opt/python@3.8/bin" >> $GITHUB_PATH
 
         # Set environment variables
         echo "TAR=gtar" >> $GITHUB_ENV
@@ -538,9 +538,9 @@ jobs:
       run: |
         # Configure macOS build environment
         if [ "$RUNNER_OS" == "macOS" ]; then
-          export PATH="$PATH:/usr/local/opt/binutils/bin"
-          export CPPFLAGS="-I/usr/local/opt/ncurses/include -I/usr/local/opt/gettext/include"
-          export LDFLAGS="-L/usr/local/opt/ncurses/lib -L/usr/local/opt/gettext/lib"
+          export PATH="$PATH:${HOMEBREW_PREFIX}/opt/binutils/bin"
+          export CPPFLAGS="-I${HOMEBREW_PREFIX}/opt/ncurses/include -I${HOMEBREW_PREFIX}/opt/gettext/include"
+          export LDFLAGS="-L${HOMEBREW_PREFIX}/opt/ncurses/lib -L${HOMEBREW_PREFIX}/opt/gettext/lib"
         fi
 
         # Create build directory
@@ -639,11 +639,11 @@ jobs:
         EOF
 
         # Set Canadian cross compilation configurations
-        if [ "${{ matrix.host.name }}" == "macos-aarch64" ]; then
-          # Building for macos-aarch64 on macos-x86_64
+        if [ "${{ matrix.host.name }}" == "macos-x86_64" ]; then
+          # Building for macos-x86_64 on macos-aarch64
           cat <<EOF >> .config
         CT_CANADIAN=y
-        CT_HOST="aarch64-apple-darwin"
+        CT_HOST="x86_64-apple-darwin"
         EOF
         elif [ "${{ matrix.host.name }}" == "windows-x86_64" ]; then
           # Building for windows-x86_64 on linux-x86_64
@@ -659,13 +659,13 @@ jobs:
         CT_GDB_CROSS_PYTHON_VARIANT=y
         EOF
 
-        if [ "${{ matrix.host.name }}" == "macos-aarch64" ]; then
-          # Clone crosskit-aarch64-darwin-libpython cross compilation kit
+        if [ "${{ matrix.host.name }}" == "macos-x86_64" ]; then
+          # Clone crosskit-x86_64-darwin-libpython cross compilation kit
           git clone \
-            https://github.com/stephanosio/crosskit-aarch64-darwin-libpython.git \
-            ${WORKSPACE}/crosskit-aarch64-darwin-libpython
+            https://github.com/stephanosio/crosskit-x86_64-darwin-libpython.git \
+            ${WORKSPACE}/crosskit-x86_64-darwin-libpython
           # Use Python 3.8.12
-          export LIBPYTHON_KIT_ROOT=${WORKSPACE}/crosskit-aarch64-darwin-libpython/python-3.8.12
+          export LIBPYTHON_KIT_ROOT=${WORKSPACE}/crosskit-x86_64-darwin-libpython/python-3.8.12
           # Set Python configuration resolver for GDB
           cat <<EOF >> .config
         CT_GDB_CROSS_PYTHON_BINARY="${LIBPYTHON_KIT_ROOT}/bin/python"
@@ -708,9 +708,9 @@ jobs:
         popd
 
         # Resolve output directory path
-        if [ "${{ matrix.host.name }}" == "macos-aarch64" ]; then
+        if [ "${{ matrix.host.name }}" == "macos-x86_64" ]; then
           OUTPUT_BASE="${WORKSPACE}/output"
-          OUTPUT_DIR="HOST-aarch64-apple-darwin"
+          OUTPUT_DIR="HOST-x86_64-apple-darwin"
         elif [ "${{ matrix.host.name }}" == "windows-x86_64" ]; then
           OUTPUT_BASE="${WORKSPACE}/output"
           OUTPUT_DIR="HOST-x86_64-w64-mingw32"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1233,7 +1233,6 @@ jobs:
 
     env:
       SUBSET_COUNT: 2
-      PYTHON_DEPS: https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/main/scripts/requirements.txt
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
 
     steps:
@@ -1275,15 +1274,6 @@ jobs:
           brew install ccache coreutils dos2unix dtc gperf jq ninja wget
         fi
 
-        # Upgrade pip
-        sudo python3 -m pip install --upgrade pip
-
-        # Install west
-        sudo pip3 install --upgrade west
-
-        # Install required Python packages
-        sudo pip3 install --upgrade -r "${{ env.PYTHON_DEPS }}"
-
         # Set environment variables
         echo "TAR=gtar" >> $GITHUB_ENV
         echo "ARTIFACT_ROOT=${GITHUB_WORKSPACE}/artifacts" >> $GITHUB_ENV
@@ -1299,20 +1289,37 @@ jobs:
         # Install required system packages
         choco install ccache dtc-msys2 gperf jq ninja wget 7zip
 
-        # Upgrade pip
-        python3 -m pip install --upgrade pip
-
-        # Install west
-        pip3 install --upgrade west
-
-        # Install required Python packages
-        pip3 install --upgrade -r "${{ env.PYTHON_DEPS }}"
-
         # Enable long paths support for Git
         git config --system core.longpaths true
 
         # Set environment variables
         echo "ARTIFACT_ROOT=${GITHUB_WORKSPACE}/artifacts" >> $GITHUB_ENV
+
+    - name: Create Python virtual environment
+      if: ${{ runner.os != 'Linux' }}
+      run: |
+        # Create Python virtual environment
+        python3 -m venv ${GITHUB_WORKSPACE}/venv
+
+        # Resolve activation script path
+        if [ "${{ runner.os }}" == "Windows" ]; then
+          VENV_ACTIVATE="${GITHUB_WORKSPACE}/venv/Scripts/activate"
+        else
+          VENV_ACTIVATE="${GITHUB_WORKSPACE}/venv/bin/activate"
+        fi
+
+        # Test Python virtual environment
+        source ${VENV_ACTIVATE}
+        which python3
+        which pip3
+
+        # Install core components
+        python3 -m pip install --upgrade pip
+        pip3 install --upgrade setuptools wheel
+
+        # Set environment variables
+        echo "VENV=${GITHUB_WORKSPACE}/venv" >> $GITHUB_ENV
+        echo "VENV_ACTIVATE=${VENV_ACTIVATE}" >> $GITHUB_ENV
 
     - name: Download version information
       uses: actions/download-artifact@v3
@@ -1379,8 +1386,23 @@ jobs:
 
         popd
 
+    - name: Install west
+      run: |
+        # Activate Python virtual environment
+        if [ ! -z "${VENV_ACTIVATE}" ]; then
+          source ${VENV_ACTIVATE}
+        fi
+
+        # Install or upgrade west
+        pip3 install --upgrade west
+
     - name: Set up Zephyr repository
       run: |
+        # Activate Python virtual environment
+        if [ ! -z "${VENV_ACTIVATE}" ]; then
+          source ${VENV_ACTIVATE}
+        fi
+
         # Create Zephyr workspace
         ZEPHYR_WORKSPACE=${GITHUB_WORKSPACE}/zephyrproject
         west init ${ZEPHYR_WORKSPACE}
@@ -1406,8 +1428,25 @@ jobs:
         echo "ZEPHYR_WORKSPACE=${ZEPHYR_WORKSPACE}" >> $GITHUB_ENV
         echo "ZEPHYR_ROOT=${ZEPHYR_WORKSPACE}/zephyr" >> $GITHUB_ENV
 
+    - name: Install Python dependencies
+      run: |
+        # Activate Python virtual environment
+        if [ ! -z "${VENV_ACTIVATE}" ]; then
+          source ${VENV_ACTIVATE}
+
+          # Install Python dependencies from the checked out Zephyr repository
+          # if running inside a virtual environment; otherwise, it is assumed
+          # that the host already provides all the required dependencies.
+          pip3 install -r ${ZEPHYR_ROOT}/scripts/requirements.txt
+        fi
+
     - name: Run test suites
       run: |
+        # Activate Python virtual environment
+        if [ ! -z "${VENV_ACTIVATE}" ]; then
+          source ${VENV_ACTIVATE}
+        fi
+
         # Create working directory
         mkdir -p test
         cd test


### PR DESCRIPTION
This series updates the CI workflow to natively build the AArch64 Linux and AArch64 macOS toolchains using the AArch64 Linux zephyr-runner and the AArch64 macOS zephyr-runner, respectively.

It also adds the test environments for the `linux-aarch64` and `macos-aarch64` distribution bundles using the AArch64 zephyr-runners.

Note that the Intel (x86) Mac Mini zephyr-runners have been phased out and replaced by the Apple Silicon (M1) Mac Mini zephyr-runners as part of this. The `macos-x86_64` toolchains are now cross-compiled from the AArch64 macOS. The testing of the `macos-x86_64` distribution bundle is done on the AArch64 macOS using Rosetta 2 emulation.

Closes #425 
Closes #442