### PR TITLE
cmake: Update Kconfig symbol name for 0.16 release

### DIFF
--- a/cmake/zephyr/Kconfig
+++ b/cmake/zephyr/Kconfig
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-config TOOLCHAIN_ZEPHYR_0_15
+config TOOLCHAIN_ZEPHYR_0_16
 	def_bool y
 	select HAS_NEWLIB_LIBC_NANO if (ARC || (ARM && !ARM64) || RISCV)
 


### PR DESCRIPTION
This commit renames the `TOOLCHAIN_ZEPHYR_0_15` Kconfig symbol to `TOOLCHAIN_ZEPHYR_0_16` in preparation for the Zephyr SDK 0.16.0 release.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>