### PR TITLE
kconfig: Signal newlib support in Kconfig too

### DIFF
--- a/cmake/zephyr/Kconfig
+++ b/cmake/zephyr/Kconfig
@@ -7,3 +7,9 @@ config TOOLCHAIN_ZEPHYR_0_16
 config TOOLCHAIN_ZEPHYR_SUPPORTS_THREAD_LOCAL_STORAGE
 	def_bool y
 	select TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
+
+config NEWLIB_SUPPORTED
+	def_bool y
+	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr"
+	help
+	  Zephyr always supports newlib for C and C++ development.


### PR DESCRIPTION
This lets Kconfig stanzas detect newlib support in the toolchain

Working on zephyr PR https://github.com/zephyrproject-rtos/zephyr/pull/54637

Signed-off-by: Keith Packard <keithp@keithp.com>