### PR TITLE
ci: Disable testing of xtensa-espressif_esp32s3_zephyr-elf toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1523,7 +1523,8 @@ jobs:
               PLATFORM_ARGS+="-p esp32s2_saola "
               ;;
             xtensa-espressif_esp32s3_zephyr-elf)
-              PLATFORM_ARGS+="-p esp32s3_devkitc "
+              # FIXME: Disabled until esp32s3_devkitc board is upstreamed.
+              # PLATFORM_ARGS+="-p esp32s3_devkitc "
               ;;
             xtensa-intel_apl_adsp_zephyr-elf)
               PLATFORM_ARGS+="-p intel_adsp_cavs15 "


### PR DESCRIPTION
This commit disables the testing of the
`xtensa-espressif_esp32s3_zephyr-elf` toolchain because the `esp32s3_devkitc` board has not been upstreamed yet.

Revert this commit when the `esp32s3_devkitc` board is upstreamed.