### PR TITLE
configs: Add common toolchain configuration file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,8 +624,9 @@ jobs:
         pushd ${WORKSPACE}/build
 
         # Load default target configurations
-        cp ${GITHUB_WORKSPACE}/configs/${{ matrix.target }}.config \
-           .config
+        cat ${GITHUB_WORKSPACE}/configs/common.config \
+            ${GITHUB_WORKSPACE}/configs/${{ matrix.target }}.config \
+            > .config
 
         # Set version information
         cat <<EOF >> .config

--- a/configs/common.config
+++ b/configs/common.config
@@ -1,0 +1,1 @@
+# Common crosstool-ng configurations for all toolchain variants


### PR DESCRIPTION
This commit introduces the common toolchain configuration file, common.config, that specifies the crosstool-ng toolchain configurations that are common to all toolchain variants.

The configurations in common.config are applied before the configurations in each toolchain configuration file.