### PR TITLE
configs: common: Add tmux support for ncurses

### DIFF
--- a/configs/common.config
+++ b/configs/common.config
@@ -1,5 +1,8 @@
 # Common crosstool-ng configurations for all toolchain variants
 
+# Ncurses
+CT_NCURSES_HOST_FALLBACKS="linux,xterm,xterm-color,xterm-256color,vt100,screen,screen-256color,tmux,tmux-256color"
+
 # Binutils
 CT_BINUTILS_SRC_CUSTOM=y
 CT_BINUTILS_CUSTOM_LOCATION="${GITHUB_WORKSPACE}/binutils"


### PR DESCRIPTION
This commit updates the common toolchain configurations to explicitly set the list of supported terminal types for the ncurses library and adds `screen`, `screen-256color`, `tmux`, `tmux-256color` terminal type support.

These terminal types are required in order to properly handle user inputs (e.g. for GDB shell) inside tmux.

---

Closes https://github.com/zephyrproject-rtos/sdk-ng/issues/633