### PR TITLE
ci: Grant write permission before toolchain output directory cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -729,14 +729,14 @@ jobs:
           OUTPUT_DIR="output"
         fi
 
+        # Grant write permission for owner
+        chmod -R u+w ${OUTPUT_BASE}/${OUTPUT_DIR}
+
         # Remove unneeded files from output directory
         pushd ${OUTPUT_BASE}/${OUTPUT_DIR}/${{ matrix.target }}
         rm -rf newlib-nano
         rm -f build.log.bz2
         popd
-
-        # Grant write permission for owner
-        chmod -R u+w ${OUTPUT_BASE}/${OUTPUT_DIR}
 
         # Rename Canadian cross-compiled toolchain output directory to
         # "output" for consistency


### PR DESCRIPTION
This commit updates the CI workflow to grant write permission to the toolchain build output directory and its sub-directories before attempting to clean up unneeded files.

This is necessary because crosstool-ng may create output directories without write permission (e.g. when building on macOS).