### PR TITLE
cmake: Use /tmp path on linux/mac

### DIFF
--- a/cmake/zephyr_sdk_export.cmake
+++ b/cmake/zephyr_sdk_export.cmake
@@ -12,13 +12,19 @@
 # Register the Zephyr-sdk package by running `cmake -P zephyr_sdk_export.cmake`
 # in this directory.
 
+if(WIN32)
+  set(MD5_PATH ${CMAKE_CURRENT_LIST_DIR})
+else()
+  set(MD5_PATH "/tmp")
+endif()
+
 set(MD5_INFILE "current_path.txt")
 
 # We write CMAKE_CURRENT_LIST_DIR into MD5_INFILE, as the content of that file
 # will be used for MD5 calculation.  This means we effectively get the MD5 of
 # CMAKE_CURRENT_LIST_DIR which must be used for CMake user package registry.
-file(WRITE ${CMAKE_CURRENT_LIST_DIR}/${MD5_INFILE} ${CMAKE_CURRENT_LIST_DIR})
-execute_process(COMMAND ${CMAKE_COMMAND} -E md5sum ${CMAKE_CURRENT_LIST_DIR}/${MD5_INFILE}
+file(WRITE ${MD5_PATH}/${MD5_INFILE} ${CMAKE_CURRENT_LIST_DIR})
+execute_process(COMMAND ${CMAKE_COMMAND} -E md5sum ${MD5_PATH}/${MD5_INFILE}
                 OUTPUT_VARIABLE MD5_SUM
 )
 string(SUBSTRING ${MD5_SUM} 0 32 MD5_SUM)
@@ -40,4 +46,4 @@ else()
   message("~/.cmake/packages/Zephyr-sdk\n")
 endif()
 
-file(REMOVE ${CMAKE_CURRENT_LIST_DIR}/${MD5_INFILE})
+file(REMOVE ${MD5_PATH}/${MD5_INFILE})


### PR DESCRIPTION
This switches to use /tmp as a temporary path on linux and mac since normal users do not generally have write permission to the system location where zephyr SDK files are located, which would otherwise prevent them from registering it.

Note: not tried this with windows/mac, worked with zephyr sdk 0.16.0 on linux