### PR TITLE
cmake: Select HAS_NEWLIB_LIBC_NANO unconditionally

### DIFF
--- a/cmake/zephyr/Kconfig
+++ b/cmake/zephyr/Kconfig
@@ -2,7 +2,7 @@
 
 config TOOLCHAIN_ZEPHYR_0_16
 	def_bool y
-	select HAS_NEWLIB_LIBC_NANO if (ARC || (ARM && !ARM64) || RISCV)
+	select HAS_NEWLIB_LIBC_NANO
 
 config TOOLCHAIN_ZEPHYR_SUPPORTS_THREAD_LOCAL_STORAGE
 	def_bool y


### PR DESCRIPTION
This commit updates the Zephyr SDK Kconfig to select `HAS_NEWLIB_LIBC_NANO` unconditionally because the Newlib nano variant is now available on all targets supported by the Zephyr SDK.