### PR TITLE
ci: Disable testing of xtensa-intel_s1000_zephyr-elf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1539,7 +1539,10 @@ jobs:
               # PLATFORM_ARGS+="-p intel_adsp_cavs15 "
               ;;
             xtensa-intel_s1000_zephyr-elf)
-              PLATFORM_ARGS+="-p intel_adsp_cavs18 "
+              # NOTE: The `intel_adsp_cavs18` board was removed from the
+              #       upstream Zephyr and there currently is no upstream
+              #       board that uses this toolchain.
+              # PLATFORM_ARGS+="-p intel_adsp_cavs18 "
               ;;
             xtensa-nxp_imx_adsp_zephyr-elf)
               PLATFORM_ARGS+="-p nxp_adsp_imx8 "


### PR DESCRIPTION
This commit updates the CI workflow to disable testing of the `xtensa-intel_s1000_zephyr-elf` toolchain because the `intel_adsp_cavs18` board was removed from the upstream Zephyr and there currently is no upstream board that uses this toolchain.