### PR TITLE
cmake: Disable Newlib-nano for Xtensa

### DIFF
--- a/cmake/zephyr/Kconfig
+++ b/cmake/zephyr/Kconfig
@@ -2,7 +2,9 @@
 
 config TOOLCHAIN_ZEPHYR_0_16
 	def_bool y
-	select HAS_NEWLIB_LIBC_NANO
+	# FIXME: Newlib-nano is disabled for Xtensa targets due to the memset
+        #        bug causing crashes (see the GitHub issue #660).
+	select HAS_NEWLIB_LIBC_NANO if !XTENSA
 
 config TOOLCHAIN_ZEPHYR_SUPPORTS_THREAD_LOCAL_STORAGE
 	def_bool y


### PR DESCRIPTION
This commit temporarily disables the Newlib nano variant for the Xtensa architecture because there is a bug in the nano `memset` implementation causing a system crash (see the GitHub issue #660).

Revert this commit when #660 is fixed.