### PR TITLE
ci: Use Zephyr topic-sdk-dev branch for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ on:
       zephyr-ref:
         description: 'Zephyr Ref (branch, tag, SHA, ...)'
         required: true
-        default: main
+        default: topic-sdk-dev
       host:
         description: 'Host'
         type: choice
@@ -76,7 +76,7 @@ env:
   BUG_URL: 'https://github.com/zephyrproject-rtos/sdk-ng/issues'
   BUNDLE_NAME: Zephyr SDK
   BUNDLE_PREFIX: zephyr-sdk
-  ZEPHYR_REF: main
+  ZEPHYR_REF: topic-sdk-dev
 
 jobs:
   # Setup


### PR DESCRIPTION
This commit updates the CI workflow to use the Zephyr `topic-sdk-dev` branch, which contains the Zephyr-side patches required for the latest Zephyr SDK changes, for testing.