### PR TITLE
openocd: Pull in ARC debug issue fix

### DIFF
--- a/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_git.bb
+++ b/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_git.bb
@@ -6,7 +6,7 @@ RDEPENDS_${PN} = "libusb1 hidapi"
 SRC_URI = " \
 	git://github.com/zephyrproject-rtos/openocd.git;protocol=https;nobranch=1 \
 	"
-SRCREV = "c5c47943dbd036079d96fe49ea9092f78abec427"
+SRCREV = "e2b6f5655e2ccd354fb8c7d0f53b93f4cb42a4f4"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This commit pulls in the OpenOCD patch that fixes the debug errors seen with the ARC platforms.

Note that this patch disables the ARC_SEC core support for the ARC platforms (see zephyrproject-rtos/openocd#53 and
foss-for-synopsys-dwc-arc-processors/openocd#51).