### PR TITLE
README: Add submodule update process

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,7 @@ To create a new Zephyr SDK release:
   the tag name should be `v0.11.0`) and add the release information.
 - Once the release is published, CI will build the Zephyr SDK bundles for all
   supported host platforms and will upload the binaries to the release page.
+
+For more detailed information on the release process, please refer to the
+[Release Process](https://github.com/zephyrproject-rtos/sdk-ng/wiki/Release-Process)
+document in the wiki.

--- a/README.md
+++ b/README.md
@@ -104,3 +104,7 @@ When updating a submodule, the following procedure should be followed:
 - Update the pull request in the Zephyr SDK repository to reference the merged
   commit in the submodule repository.
 - Merge the pull request in the Zephyr SDK repository.
+
+When updating the `picolibc` submodule, the `picolibc` module in the `west.yml`
+of the [main Zephyr repository](https://github.com/zephyrproject-rtos/zephyr)
+must also be updated to reference the same commit.

--- a/README.md
+++ b/README.md
@@ -85,3 +85,22 @@ To create a new Zephyr SDK release:
 For more detailed information on the release process, please refer to the
 [Release Process](https://github.com/zephyrproject-rtos/sdk-ng/wiki/Release-Process)
 document in the wiki.
+
+## Submodule Update Process
+
+The Zephyr SDK repository contains various submodules, such as `binutils` and
+`gcc`, required for building the Zephyr SDK.
+
+When updating a submodule, the following procedure should be followed:
+
+- Push a topic branch to the submodule repository.
+- Create a pull request from the topic branch to the default (current) branch
+  of the submodule repository.
+- Create a pull request in the Zephyr SDK repository to update the submodule
+  reference to the tip of the topic (pull request) branch.
+- When the pull request in the Zephyr SDK repository passes the CI and the
+  submodule pull request is sufficiently reviewed, merge the submodule pull
+  request.
+- Update the pull request in the Zephyr SDK repository to reference the merged
+  commit in the submodule repository.
+- Merge the pull request in the Zephyr SDK repository.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ The Zephyr SDK bundle releases are available for the following host platforms:
 - macOS (AArch64, x86-64)
 - Windows (x86-64)
 
-These binaries can be downloaded from here:
+These binaries can be downloaded from
+[here](https://github.com/zephyrproject-rtos/sdk-ng/tags).
 
-https://github.com/zephyrproject-rtos/sdk-ng/releases
+For future release plans, please refer to the
+[Release Plan](https://github.com/zephyrproject-rtos/sdk-ng/wiki/Release-Plan)
+document in the wiki.
 
 ## Build Process
 


### PR DESCRIPTION
This series adds the process for updating the submodules in the Zephyr SDK repository, along with the requirement for keeping the Zephyr SDK `picolibc` submodule and the Zephyr `picolibc` module synchronised.

Related to https://github.com/zephyrproject-rtos/zephyr/pull/58006

Part of https://github.com/zephyrproject-rtos/zephyr/issues/49922