### PR TITLE
meta-zephyr-sdk: arc_qemu: Update to 2023.07.28 release

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/arc_qemu/arc-qemu_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/arc_qemu/arc-qemu_git.bb
@@ -5,7 +5,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
                     file://COPYING.LIB;endline=24;md5=8c5efda6cf1e1b03dcfd0e6c0d271c7f"
 
-SRCREV = "4dad023e2a33b8024abf770f69a122ee5d5e2c9c"
+SRCREV = "b46c4ec2d07a4c56c426b3d48195d6f2902226e5"
 SRC_URI = "git://github.com/foss-for-synopsys-dwc-arc-processors/qemu.git;protocol=https;nobranch=1 \
 	   file://cross.patch \
 "


### PR DESCRIPTION
This commit updates the ARC QEMU to 2023.07.28 tag.

There are multiple fixes, one of whose is fix of buggy delay slot implementation, which was causing issues like
https://github.com/zephyrproject-rtos/zephyr/issues/54720 (and most likely https://github.com/zephyrproject-rtos/zephyr/issues/60071)

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/54720
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/60071