### PR TITLE
ci: when testing with twister, force toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1566,6 +1566,7 @@ jobs:
         # Run tests with twister
         TWISTER="${ZEPHYR_ROOT}/scripts/twister"
         ${TWISTER} -v -N -M --force-color --inline-logs --retry-failed 3 \
+                   --force-toolchain \
                    --subset ${{ matrix.subset }}/${{ env.SUBSET_COUNT }} \
                    ${HOST_ARGS} \
                    ${TEST_ARGS} \


### PR DESCRIPTION
Some of the test platforms might not be enabled with zephyr toolchain
yet, so force toolchain to be able to test platforms with the new SDK.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
