### PR TITLE
overlays/mt8195_adsp: Fix typo

### DIFF
--- a/overlays/xtensa_mtk_mt8195/gdb/gdb/xtensa-config.c
+++ b/overlays/xtensa_mtk_mt8195/gdb/gdb/xtensa-config.c
@@ -496,4 +496,4 @@ static xtensa_register_t rmap[] =
   XTREG_END
 };
 
-xtensa_gdbarch_tdep xtensa_tdep rmap);
+xtensa_gdbarch_tdep xtensa_tdep (rmap);


### PR DESCRIPTION
One byte error in copy/paste code.  Because I'm congenitally unable to write trivial syntax correctly the first time.  But also because we have no way to execute this code except inside of a Github CI container.