### PR TITLE
xtensa: dc233c: disable thread local storage

### DIFF
--- a/configs/xtensa-dc233c_zephyr-elf.config
+++ b/configs/xtensa-dc233c_zephyr-elf.config
@@ -6,3 +6,4 @@ CT_ARCH_XTENSA=y
 CT_XTENSA_CUSTOM=y
 CT_TARGET_VENDOR="dc233c_zephyr"
 CT_TARGET_CFLAGS="-ftls-model=local-exec"
+CT_CC_GCC_CONFIG_TLS=n


### PR DESCRIPTION
The main Zephyr arch code does not support thread local storage yet. So set CT_CC_GCC_CONFIG_TLS to NO so picolibc would not be built with TLS support.