### PR TITLE
Picolibc 1.8.4

### DIFF
--- a/configs/common.config
+++ b/configs/common.config
@@ -72,4 +72,4 @@ CT_PICOLIBC_SRC_CUSTOM=y
 CT_PICOLIBC_CUSTOM_LOCATION="${GITHUB_WORKSPACE}/picolibc"
 CT_LIBC_PICOLIBC_GLOBAL_ATEXIT=y
 CT_LIBC_PICOLIBC_EXTRA_SECTIONS=y
-CT_LIBC_PICOLIBC_EXTRA_CONFIG_ARRAY="-Dthread-local-storage=auto -Derrno-function=zephyr -Dsysroot-install=true -Dsysroot-install-skip-checks=true"
+CT_LIBC_PICOLIBC_EXTRA_CONFIG_ARRAY="-Dthread-local-storage=auto -Derrno-function=zephyr -Dsysroot-install=true -Dsysroot-install-skip-checks=true -Dio-long-long=true -Dprintf-small-ultoa=true -Dassert-verbose=false"


### PR DESCRIPTION
Pull in version 1.8.4 with a few configuration tweaks:

 1. Add long long support to 'integer' printf variant, but not the 'minimal' printf variant.
 2. Avoid soft division in binary to decimal conversions.
 3. Remove filename/expression strings from 'assert' macros to avoid filling memory with strings.

There is a matching Zephyr PR, https://github.com/zephyrproject-rtos/zephyr/pull/62882