### PR TITLE
Integrate picolibc 1.8.5

### DIFF
--- a/configs/common.config
+++ b/configs/common.config
@@ -72,4 +72,4 @@ CT_PICOLIBC_SRC_CUSTOM=y
 CT_PICOLIBC_CUSTOM_LOCATION="${GITHUB_WORKSPACE}/picolibc"
 CT_LIBC_PICOLIBC_GLOBAL_ATEXIT=y
 CT_LIBC_PICOLIBC_EXTRA_SECTIONS=y
-CT_LIBC_PICOLIBC_EXTRA_CONFIG_ARRAY="-Dthread-local-storage=auto -Derrno-function=zephyr -Dsysroot-install=true -Dsysroot-install-skip-checks=true"
+CT_LIBC_PICOLIBC_EXTRA_CONFIG_ARRAY="-Dthread-local-storage=auto -Derrno-function=zephyr -Dsysroot-install=true -Dsysroot-install-skip-checks=true -Dassert-verbose=false"


### PR DESCRIPTION
This replaces the PR bringing picolibc 1.8.4 into the SDK -- that one increased the size of several applications as it changed the default printf configuration. 1.8.5 goes back to the old settings but adds a new variant, 'long long', which can be selected by applications needing full integer printf support.