### PR TITLE
ci: rename board from qemu_xtensa_dc233c to qemu_xtensa_mmu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1529,7 +1529,7 @@ jobs:
               PLATFORM_ARGS+="-p qemu_x86_64 "
               ;;
             xtensa-dc233c_zephyr-elf)
-              PLATFORM_ARGS+="-p qemu_xtensa_dc233c "
+              PLATFORM_ARGS+="-p qemu_xtensa_mmu "
               ;;
             xtensa-espressif_esp32_zephyr-elf)
               PLATFORM_ARGS+="-p esp32_devkitc_wroom "


### PR DESCRIPTION
The board used for running Xtensa with MMU has been renamed to qemu_xtensa_mmu on Zephyr main repo. So update the CI yaml file to match.