### PR TITLE
ci: Use Zephyr collab-sdk-dev branch for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ on:
       zephyr-ref:
         description: 'Zephyr Ref (branch, tag, SHA, ...)'
         required: true
-        default: topic-sdk-dev
+        default: collab-sdk-dev
       host:
         description: 'Host'
         type: choice
@@ -80,7 +80,7 @@ env:
   BUG_URL: 'https://github.com/zephyrproject-rtos/sdk-ng/issues'
   BUNDLE_NAME: Zephyr SDK
   BUNDLE_PREFIX: zephyr-sdk
-  ZEPHYR_REF: topic-sdk-dev
+  ZEPHYR_REF: collab-sdk-dev
 
 jobs:
   # Setup


### PR DESCRIPTION
The "topic" branches have been superseded by the "collab" branches in the upstream Zephyr repository.

This commit updates the Zephyr SDK CI to use the renamed `collab-sdk-dev` branch, complying to the new guidelines.