### PR TITLE
ci: Disable AArch64 Linux SDK build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
 
         if [ "${build_host_all}" == "y" ]; then
           build_host_linux_x86_64="y"
-          build_host_linux_aarch64="y"
+          # build_host_linux_aarch64="y"
           build_host_macos_x86_64="y"
           build_host_macos_aarch64="y"
           build_host_windows_x86_64="y"


### PR DESCRIPTION
This commit temporarily disables AArch64 Linux Zephyr SDK build because the AArch64 CI runner AWS spot instances are too frequently shut down and unable to complete the full build cycle.

Re-enable this when the self-hosted zephyr-runner v2 is deployed and available for production use.