### PR TITLE
DNM: RISCV: add rv64{32}-imfc support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,8 @@
 	url = https://github.com/zephyrproject-rtos/newlib-cygwin.git
 [submodule "gcc"]
 	path = gcc
-	url = https://github.com/zephyrproject-rtos/gcc.git
+	url = https://github.com/quic-lingutla/gcc.git
+	branch = risc_imfc
 [submodule "gdb"]
 	path = gdb
 	url = https://github.com/zephyrproject-rtos/binutils-gdb.git


### PR DESCRIPTION
Add RISCV ISA rv64-imfc support.

---

GCC PR: https://github.com/zephyrproject-rtos/gcc/pull/26