### PR TITLE
ci: Increase macOS workspace volume size to 150GB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,7 +522,7 @@ jobs:
 
         # Create case-sensitive workspace volume for macOS
         hdiutil create ${RUNNER_TEMP}/Workspace.sparseimage \
-                       -volname Workspace -type SPARSE -size 70g -fs HFSX
+                       -volname Workspace -type SPARSE -size 150g -fs HFSX
         hdiutil mount ${RUNNER_TEMP}/Workspace.sparseimage -mountpoint ${WORKSPACE}
 
         # Install required dependencies if running inside a GitHub-hosted runner


### PR DESCRIPTION
This commit increases the macOS runner workspace volume size from 70GB to 150GB because 70GB is insufficient for the toolchain builds for the architectures with many multi-lib variants to successfully complete.

Note that the size of 150GB was chosen to match the workspace volume size available on the Linux zephyr-runner v2 instances.