### PR TITLE
ci: Update test platform names for HWMv2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1566,10 +1566,7 @@ jobs:
               PLATFORM_ARGS+="-p imx8mp_evk/mimx8ml8/adsp "
               ;;
             xtensa-nxp_imx8ulp_adsp_zephyr-elf)
-              # FIXME: Disabled because nxp_adsp_imx8ulp support has not been
-              #        merged yet. Enable when zephyrproject-rtos/zephyr#63751
-              #        is merged.
-              #PLATFORM_ARGS+="-p nxp_adsp_imx8ulp "
+              PLATFORM_ARGS+="-p imx8ulp_evk/mimx8ud7/adsp "
               ;;
             xtensa-sample_controller_zephyr-elf)
               PLATFORM_ARGS+="-p qemu_xtensa "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1559,6 +1559,10 @@ jobs:
             xtensa-intel_tgl_adsp_zephyr-elf)
               PLATFORM_ARGS+="-p intel_adsp/cavs25 "
               ;;
+            xtensa-mtk_mt8195_adsp_zephyr-elf)
+              # xtensa-mtk_mt8195_adsp_zephyr-elf is untested because no
+              # upstream user platform is currently available.
+              ;;
             xtensa-nxp_imx_adsp_zephyr-elf)
               PLATFORM_ARGS+="-p imx8qm_mek/mimx8qm6/adsp "
               ;;
@@ -1570,6 +1574,10 @@ jobs:
               ;;
             xtensa-nxp_rt500_adsp_zephyr-elf)
               PLATFORM_ARGS+="-p mimxrt595_evk/mimxrt595s/f1 "
+              ;;
+            xtensa-nxp_rt600_adsp_zephyr-elf)
+              # xtensa-nxp_rt600_adsp_zephyr-elf is untested because no
+              # upstream user platform is currently available.
               ;;
             xtensa-sample_controller_zephyr-elf)
               PLATFORM_ARGS+="-p qemu_xtensa "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1507,17 +1507,17 @@ jobs:
               PLATFORM_ARGS+="-p qemu_cortex_a53 "
               ;;
             arc64-zephyr-elf)
-              PLATFORM_ARGS+="-p qemu_arc_hs6x "
+              PLATFORM_ARGS+="-p qemu_arc/qemu_arc_hs6x "
               ;;
             arc-zephyr-elf)
-              PLATFORM_ARGS+="-p qemu_arc_em "
-              PLATFORM_ARGS+="-p qemu_arc_hs "
+              PLATFORM_ARGS+="-p qemu_arc/qemu_arc_em "
+              PLATFORM_ARGS+="-p qemu_arc/qemu_arc_hs "
               ;;
             arm-zephyr-eabi)
               PLATFORM_ARGS+="-p qemu_cortex_m0 "
-              PLATFORM_ARGS+="-p mps2_an385 "
-              PLATFORM_ARGS+="-p mps2_an521 "
-              PLATFORM_ARGS+="-p mps3_an547 "
+              PLATFORM_ARGS+="-p mps2/an385 "
+              PLATFORM_ARGS+="-p mps2/an521/cpu0 "
+              PLATFORM_ARGS+="-p mps3/an547 "
               ;;
             # TODO: Release the microblaze arch source in a public repo
             # microblazeel-zephyr-elf)
@@ -1542,28 +1542,28 @@ jobs:
               PLATFORM_ARGS+="-p qemu_x86_64 "
               ;;
             xtensa-dc233c_zephyr-elf)
-              PLATFORM_ARGS+="-p qemu_xtensa_mmu "
+              PLATFORM_ARGS+="-p qemu_xtensa/dc233c/mmu "
               ;;
             xtensa-espressif_esp32_zephyr-elf)
-              PLATFORM_ARGS+="-p esp32_devkitc_wroom "
+              PLATFORM_ARGS+="-p esp32_devkitc_wroom/esp32/procpu "
               ;;
             xtensa-espressif_esp32s2_zephyr-elf)
               PLATFORM_ARGS+="-p esp32s2_saola "
               ;;
             xtensa-espressif_esp32s3_zephyr-elf)
-              PLATFORM_ARGS+="-p esp32s3_devkitm "
+              PLATFORM_ARGS+="-p esp32s3_devkitm/esp32s3/procpu "
               ;;
             xtensa-intel_ace15_mtpm_zephyr-elf)
-              PLATFORM_ARGS+="-p intel_adsp_ace15_mtpm "
+              PLATFORM_ARGS+="-p intel_adsp/ace15_mtpm "
               ;;
             xtensa-intel_tgl_adsp_zephyr-elf)
-              PLATFORM_ARGS+="-p intel_adsp_cavs25 "
+              PLATFORM_ARGS+="-p intel_adsp/cavs25 "
               ;;
             xtensa-nxp_imx_adsp_zephyr-elf)
-              PLATFORM_ARGS+="-p nxp_adsp_imx8 "
+              PLATFORM_ARGS+="-p imx8qm_mek/mimx8qm6/adsp "
               ;;
             xtensa-nxp_imx8m_adsp_zephyr-elf)
-              PLATFORM_ARGS+="-p nxp_adsp_imx8m "
+              PLATFORM_ARGS+="-p imx8mp_evk/mimx8ml8/adsp "
               ;;
             xtensa-nxp_imx8ulp_adsp_zephyr-elf)
               # FIXME: Disabled because nxp_adsp_imx8ulp support has not been

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1568,6 +1568,9 @@ jobs:
             xtensa-nxp_imx8ulp_adsp_zephyr-elf)
               PLATFORM_ARGS+="-p imx8ulp_evk/mimx8ud7/adsp "
               ;;
+            xtensa-nxp_rt500_adsp_zephyr-elf)
+              PLATFORM_ARGS+="-p mimxrt595_evk/mimxrt595s/f1 "
+              ;;
             xtensa-sample_controller_zephyr-elf)
               PLATFORM_ARGS+="-p qemu_xtensa "
               ;;


### PR DESCRIPTION
Update test platform names for HWMv2 after the `collab-sdk-dev` branch fast-forward.

While at it, also update the test target toolchain list to include all currently available toolchains.