### PR TITLE
Revert "configs: common: enable c++11 thread support via c11 threads"

### DIFF
--- a/configs/aarch64-zephyr-elf.config
+++ b/configs/aarch64-zephyr-elf.config
@@ -5,4 +5,4 @@ CT_ARCH_64=y
 CT_TARGET_VENDOR="zephyr"
 CT_TARGET_CFLAGS="-moverride=tune=no_ldp_stp_qregs -ftls-model=local-exec"
 CT_MULTILIB=y
-CT_GDB_CROSS_EXTRA_CONFIG_ARRAY="--enable-targets=arm-zephyr-eabi --enable-threads=c11 --enable-libstdcxx-time=c11 --enable-libstdcxx-threads"
+CT_GDB_CROSS_EXTRA_CONFIG_ARRAY="--enable-targets=arm-zephyr-eabi"

--- a/configs/common.config
+++ b/configs/common.config
@@ -15,11 +15,8 @@ CT_GDB_CUSTOM_LOCATION="${GITHUB_WORKSPACE}/gdb"
 # GCC
 CT_GCC_SRC_CUSTOM=y
 CT_GCC_CUSTOM_LOCATION="${GITHUB_WORKSPACE}/gcc"
-# NOTE: --enable-threads=c11 is still necessary here to override the value inherited by
-# build/cc/gcc.sh with baremetal "mode"
-CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array --enable-threads=c11 --enable-libstdcxx-time=c11 --enable-libstdcxx-threads"
+CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array"
 CT_CC_LANG_CXX=y
-CT_THREADS_C11=y
 
 # Newlib
 CT_NEWLIB_SRC_CUSTOM=y

--- a/configs/x86_64-zephyr-elf.config
+++ b/configs/x86_64-zephyr-elf.config
@@ -6,4 +6,4 @@ CT_TARGET_VENDOR="zephyr"
 CT_TARGET_CFLAGS="-ftls-model=local-exec"
 CT_MULTILIB=y
 CT_BINUTILS_EXTRA_CONFIG_ARRAY="--enable-targets=x86_64-pep"
-CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array --with-cpu-32=i586 --with-arch-32=i586 --with-cpu-64=generic --with-arch-64=x86-64  --enable-threads=c11 --enable-libstdcxx-time=c11 --enable-libstdcxx-threads"
+CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array --with-cpu-32=i586 --with-arch-32=i586 --with-cpu-64=generic --with-arch-64=x86-64"


### PR DESCRIPTION
This reverts the toolchain configs enabling C11 threads-based libstdc++ gthread support introduced in https://github.com/zephyrproject-rtos/sdk-ng/pull/735.

This is intended to be a temporary workaround for https://github.com/zephyrproject-rtos/sdk-ng/issues/751 until one of the solutions suggested in https://github.com/zephyrproject-rtos/gcc/pull/30#issuecomment-2094635990 is implemented.

GCC PR: https://github.com/zephyrproject-rtos/gcc/pull/30