### PR TITLE
ci: Build Zephyr libc and C++ tests and samples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1588,6 +1588,9 @@ jobs:
         # Generate test list
         TEST_ARGS="
             -T ${ZEPHYR_ROOT}/samples/hello_world
+            -T ${ZEPHYR_ROOT}/samples/cpp/hello_world
+            -T ${ZEPHYR_ROOT}/tests/lib/c_lib
+            -T ${ZEPHYR_ROOT}/tests/lib/cpp
             -T ${ZEPHYR_ROOT}/tests/lib/newlib
             "
 


### PR DESCRIPTION
This commit updates the CI toolchain test job to build and run Zephyr libc and C++ tests and samples in order to catch more C/C++ library related regressions in the SDK CI.