### PR TITLE
ci: Trigger on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,12 @@ on:
     branches:
     - main
     - topic-*
+    - v*-branch
   pull_request_target:
     branches:
     - main
     - topic-*
+    - v*-branch
   workflow_call:
     secrets:
       AWS_CACHE_SDK_ACCESS_KEY_ID:


### PR DESCRIPTION
This commit updates the CI workflow to trigger on pushes to the release branches (`v*-branch`), in preparation for the upcoming maintenance releases.