### PR TITLE
ci: Use sdk-build v1.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
           MATRIX_HOSTS+='{
               "name": "linux-x86_64",
               "runner": "zephyr-runner-v2-linux-x64-4xlarge",
-              "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.3.0",
+              "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.3.1",
               "archive": "tar.xz"
             },'
         fi
@@ -244,7 +244,7 @@ jobs:
           MATRIX_HOSTS+='{
               "name": "linux-aarch64",
               "runner": "zephyr-runner-v2-linux-arm64-4xlarge",
-              "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.3.0",
+              "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.3.1",
               "archive": "tar.xz"
             },'
         fi
@@ -271,7 +271,7 @@ jobs:
           MATRIX_HOSTS+='{
               "name": "windows-x86_64",
               "runner": "zephyr-runner-v2-linux-x64-4xlarge",
-              "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.3.0",
+              "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.3.1",
               "archive": "7z"
             },'
         fi


### PR DESCRIPTION
This commit updates the CI workflow to use the sdk-build image v1.3.1, which is based on Debian 10 (Buster) and contains Python 3.8.