### PR TITLE
crosstool-ng: Pull in libstdc++ header path fix for additional libc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1584,17 +1584,11 @@ jobs:
         # Generate test list
         TEST_ARGS="
             -T ${ZEPHYR_ROOT}/samples/hello_world
+            -T ${ZEPHYR_ROOT}/samples/cpp/hello_world
             -T ${ZEPHYR_ROOT}/tests/lib/c_lib
+            -T ${ZEPHYR_ROOT}/tests/lib/cpp
             -T ${ZEPHYR_ROOT}/tests/lib/newlib
             "
-
-        # FIXME: Build C++ samples and tests only for Linux hosts because there
-        #        is a known issue causing link failures on non-Linux hosts (see
-        #        GitHub issue #760).
-        if [ "${{ runner.os }}" == "Linux" ]; then
-          TEST_ARGS+="-T ${ZEPHYR_ROOT}/samples/cpp/hello_world "
-          TEST_ARGS+="-T ${ZEPHYR_ROOT}/tests/lib/cpp "
-        fi
 
         # Run tests with twister
         TWISTER="${ZEPHYR_ROOT}/scripts/twister"


### PR DESCRIPTION
This commit pulls in the crosstool-ng patch that fixes the wrong
libstdc++ C library header path, specified using `--with-headers`
argument, for additional libc variants such as newlib-nano and picolibc.

crosstool-ng PR: https://github.com/zephyrproject-rtos/crosstool-ng/pull/29