### PR TITLE
ci: Do not remove artifacts when running twister

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1602,7 +1602,7 @@ jobs:
 
         # Run tests with twister
         TWISTER="${ZEPHYR_ROOT}/scripts/twister"
-        ${TWISTER} -v -N -M --force-color --inline-logs --retry-failed 3 \
+        ${TWISTER} -v -N --force-color --inline-logs --retry-failed 3 \
                    --force-toolchain \
                    --subset ${{ matrix.subset }}/${{ env.SUBSET_COUNT }} \
                    ${HOST_ARGS} \


### PR DESCRIPTION
This removes the the `-M` (runtime artifact cleanup) parameter from twister invocation because it causes instability when running on Windows and the artifacts for the passing tests are already cleaned up without it.