### PR TITLE
ci: Increase test subset count to 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1277,10 +1277,10 @@ jobs:
       fail-fast: false
       matrix:
         testenv: ${{ fromJSON(needs.setup.outputs.testenvs) }}
-        subset: [ 1, 2 ]
+        subset: [ 1, 2, 3 ]
 
     env:
-      SUBSET_COUNT: 2
+      SUBSET_COUNT: 3
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
 
     steps:


### PR DESCRIPTION
This commit increases the subset count for running Zephyr tests to 3 because tests are taking up to 3 hours to complete with the subset count of 2.