### PR TITLE
[v0.16-branch] ci: Run tests against Zephyr v3.7 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ env:
   BUG_URL: 'https://github.com/zephyrproject-rtos/sdk-ng/issues'
   BUNDLE_NAME: Zephyr SDK
   BUNDLE_PREFIX: zephyr-sdk
-  ZEPHYR_REF: collab-sdk-dev
+  ZEPHYR_REF: v3.7-branch
 
 jobs:
   # Setup


### PR DESCRIPTION
This commit updates the CI workflow in the SDK 0.16 LTS branch to run tests against the Zephyr v3.7 LTS3 branch.