### PR TITLE
[v0.16-branch] ci: Disable testing of xtensa-intel_ace30_ptl_zephyr-elf toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1575,7 +1575,9 @@ jobs:
               PLATFORM_ARGS+="-p intel_adsp/ace15_mtpm "
               ;;
             xtensa-intel_ace30_ptl_zephyr-elf)
-              PLATFORM_ARGS+="-p intel_adsp/ace30_ptl "
+              # xtensa-intel_ace30_ptl_zephyr-elf is untested because it is
+              # currently unsupported in the Zephyr v3.7-branch.
+              # PLATFORM_ARGS+="-p intel_adsp/ace30_ptl "
               ;;
             xtensa-intel_tgl_adsp_zephyr-elf)
               PLATFORM_ARGS+="-p intel_adsp/cavs25 "


### PR DESCRIPTION
This commit disables the testing of xtensa-intel_ace30_ptl_zephyr-elf toolchain because the Zephyr v3.7-branch currently does not support it.