### PR TITLE
ci: Increase toolchain build timeout to 12 hours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,6 +426,7 @@ jobs:
     runs-on:
       group: ${{ matrix.host.runner }}
     container: ${{ matrix.host.container }}
+    timeout-minutes: 720 
 
     defaults:
       run:


### PR DESCRIPTION
This commit increases the CI workflow toolchain build job timeout to 12 hours because the default value of 6 hours is insufficient for the toolchains with many multi-lib variants (e.g. ARM And RISC-V).