### PR TITLE
scripts: Fix using deprecated/removed wget option

### DIFF
--- a/scripts/template_setup_posix
+++ b/scripts/template_setup_posix
@@ -215,7 +215,7 @@ for toolchain in ${inst_toolchains[@]}; do
   echo "Installing '${toolchain}' toolchain ..."
 
   # Download toolchain archive
-  wget -q --show-progress -N -O "${toolchain_filename}" "${toolchain_uri}"
+  wget -q --progress=bar -N -O "${toolchain_filename}" "${toolchain_uri}"
   if [ $? != 0 ]; then
     rm -f "${toolchain_filename}"
     echo "ERROR: Toolchain download failed"

--- a/scripts/template_setup_win
+++ b/scripts/template_setup_win
@@ -143,7 +143,7 @@ for %%t in (%INST_TOOLCHAINS%) do (
     echo Installing '%%t' toolchain ...
 
     REM # Download toolchain archive
-    wget -q --show-progress -N -O !TOOLCHAIN_FILENAME! !TOOLCHAIN_URI!
+    wget -q --progress=bar -N -O !TOOLCHAIN_FILENAME! !TOOLCHAIN_URI!
     if [!ERRORLEVEL!] neq [0] (
       del /q !TOOLCHAIN_FILENAME!
       echo ERROR: Toolchain download failed


### PR DESCRIPTION
Recent wget versions don't have the --show-progress option anymore and will generate a "wget: unrecognized option '--show-progress'" error (this happens e.g. with latest Fedora). The correct option to use seems to be --progress=bar, which should do the same thing.