### PR TITLE
[topic-clang] Add LLVM RISC-V multi-libs

### DIFF
--- a/cmake/zephyr/llvm/target.cmake
+++ b/cmake/zephyr/llvm/target.cmake
@@ -21,7 +21,12 @@ if("${ARCH}" STREQUAL "arm")
   endif()
 elseif("${ARCH}" STREQUAL "arm64")
   set(triple aarch64-none-elf)
-# TODO: Add RISC-V target support.
+elseif("${ARCH}" STREQUAL "riscv")
+  if(CONFIG_64BIT)
+    set(triple riscv64-none-elf)
+  else()
+    set(triple riscv32-none-elf)
+  endif()
 endif()
 
 if(DEFINED triple)

--- a/scripts/llvm/CMakeLists.txt
+++ b/scripts/llvm/CMakeLists.txt
@@ -1898,9 +1898,89 @@ add_library_variants_for_cpu(
 )
 ## RV32E
 add_library_variants_for_cpu(
-    rv32e_zicsr_zifencei
+    rv32e_zicsr_zifencei_ilp32e
     COMPILE_FLAGS "-march=rv32e_zicsr_zifencei -mabi=ilp32e"
-    MULTILIB_FLAGS "--target=riscv32-unknown-none-elf"
+    MULTILIB_FLAGS "--target=riscv32-unknown-none-elf -march=rv32e2p0_zicsr2p0_zifencei2p0 -mabi=ilp32e"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv32"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv32em_zicsr_zifencei_ilp32e
+    COMPILE_FLAGS "-march=rv32em_zicsr_zifencei -mabi=ilp32e"
+    MULTILIB_FLAGS "--target=riscv32-unknown-none-elf -march=rv32e2p0_m2p0_zicsr2p0_zifencei2p0_zmmul1p0 -mabi=ilp32e"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv32"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv32emc_zicsr_zifencei_ilp32e
+    COMPILE_FLAGS "-march=rv32emc_zicsr_zifencei -mabi=ilp32e"
+    MULTILIB_FLAGS "--target=riscv32-unknown-none-elf -march=rv32e2p0_m2p0_c2p0_zicsr2p0_zifencei2p0_zmmul1p0 -mabi=ilp32e"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv32"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv32emc_zicsr_zifencei_zba_zbb_zbc_zbs_ilp32e
+    COMPILE_FLAGS "-march=rv32emc_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=ilp32e"
+    MULTILIB_FLAGS "--target=riscv32-unknown-none-elf -march=rv32e2p0_m2p0_c2p0_zicsr2p0_zifencei2p0_zmmul1p0_zba1p0_zbb1p0_zbc1p0_zbs1p0 -mabi=ilp32e"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv32"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv32emc_zicsr_ilp32e
+    COMPILE_FLAGS "-march=rv32emc_zicsr -mabi=ilp32e"
+    MULTILIB_FLAGS "--target=riscv32-unknown-none-elf -march=rv32e2p0_m2p0_c2p0_zicsr2p0_zmmul1p0 -mabi=ilp32e"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv32"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv32emc_zicsr_zba_zbb_zbc_zbs_ilp32e
+    COMPILE_FLAGS "-march=rv32emc_zicsr_zba_zbb_zbc_zbs -mabi=ilp32e"
+    MULTILIB_FLAGS "--target=riscv32-unknown-none-elf -march=rv32e2p0_m2p0_c2p0_zicsr2p0_zmmul1p0_zba1p0_zbb1p0_zbc1p0_zbs1p0 -mabi=ilp32e"
     PICOLIBC_BUILD_TYPE "release"
     QEMU_MACHINE "none"
     QEMU_CPU "rv32"

--- a/scripts/llvm/CMakeLists.txt
+++ b/scripts/llvm/CMakeLists.txt
@@ -1995,9 +1995,137 @@ add_library_variants_for_cpu(
 )
 ## RV64I
 add_library_variants_for_cpu(
-    rv64i_zicsr_zifencei
+    rv64i_zicsr_zifencei_lp64
     COMPILE_FLAGS "-march=rv64i_zicsr_zifencei -mabi=lp64 -mcmodel=medany"
-    MULTILIB_FLAGS "--target=riscv64-unknown-none-elf"
+    MULTILIB_FLAGS "--target=riscv64-unknown-none-elf -march=rv64i2p1_zicsr2p0_zifencei2p0 -mabi=lp64"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv64"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv64im_zicsr_zifencei_lp64
+    COMPILE_FLAGS "-march=rv64im_zicsr_zifencei -mabi=lp64 -mcmodel=medany"
+    MULTILIB_FLAGS "--target=riscv64-unknown-none-elf -march=rv64i2p1_m2p0_zicsr2p0_zifencei2p0_zmmul1p0 -mabi=lp64"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv64"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv64im_zicsr_zifencei_zba_zbb_zbc_zbs_lp64
+    COMPILE_FLAGS "-march=rv64im_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=lp64 -mcmodel=medany"
+    MULTILIB_FLAGS "--target=riscv64-unknown-none-elf -march=rv64i2p1_m2p0_zicsr2p0_zifencei2p0_zmmul1p0_zba1p0_zbb1p0_zbc1p0_zbs1p0 -mabi=lp64"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv64"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv64imac_zicsr_zifencei_lp64
+    COMPILE_FLAGS "-march=rv64imac_zicsr_zifencei -mabi=lp64 -mcmodel=medany"
+    MULTILIB_FLAGS "--target=riscv64-unknown-none-elf -march=rv64i2p1_m2p0_a2p1_c2p0_zicsr2p0_zifencei2p0_zmmul1p0 -mabi=lp64"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv64"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv64imac_zicsr_zifencei_zba_zbb_zbc_zbs_lp64
+    COMPILE_FLAGS "-march=rv64imac_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=lp64 -mcmodel=medany"
+    MULTILIB_FLAGS "--target=riscv64-unknown-none-elf -march=rv64i2p1_m2p0_a2p1_c2p0_zicsr2p0_zifencei2p0_zmmul1p0_zba1p0_zbb1p0_zbc1p0_zbs1p0 -mabi=lp64"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv64"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv64imafdc_zicsr_zifencei_lp64d
+    COMPILE_FLAGS "-march=rv64imafdc_zicsr_zifencei -mabi=lp64d -mcmodel=medany"
+    MULTILIB_FLAGS "--target=riscv64-unknown-none-elf -march=rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zifencei2p0_zmmul1p0 -mabi=lp64d"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv64"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv64imafd_zicsr_zifencei_lp64d
+    COMPILE_FLAGS "-march=rv64imafd_zicsr_zifencei -mabi=lp64d -mcmodel=medany"
+    MULTILIB_FLAGS "--target=riscv64-unknown-none-elf -march=rv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0 -mabi=lp64d"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv64"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv64imfc_zicsr_zifencei_lp64f
+    COMPILE_FLAGS "-march=rv64imfc_zicsr_zifencei -mabi=lp64f -mcmodel=medany"
+    MULTILIB_FLAGS "--target=riscv64-unknown-none-elf -march=rv64i2p1_m2p0_f2p2_c2p0_zicsr2p0_zifencei2p0_zmmul1p0 -mabi=lp64f"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv64"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs_lp64f
+    COMPILE_FLAGS "-march=rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=lp64f -mcmodel=medany"
+    MULTILIB_FLAGS "--target=riscv64-unknown-none-elf -march=rv64i2p1_m2p0_f2p2_c2p0_zicsr2p0_zifencei2p0_zmmul1p0_zba1p0_zbb1p0_zbc1p0_zbs1p0 -mabi=lp64f"
     PICOLIBC_BUILD_TYPE "release"
     QEMU_MACHINE "none"
     QEMU_CPU "rv64"

--- a/scripts/llvm/CMakeLists.txt
+++ b/scripts/llvm/CMakeLists.txt
@@ -1769,9 +1769,121 @@ add_library_variants_for_cpu(
 # RISC-V multilibs
 ## RV32I
 add_library_variants_for_cpu(
-    rv32i_zicsr_zifencei
+    rv32i_zicsr_zifencei_ilp32
     COMPILE_FLAGS "-march=rv32i_zicsr_zifencei -mabi=ilp32"
-    MULTILIB_FLAGS "--target=riscv32-unknown-none-elf"
+    MULTILIB_FLAGS "--target=riscv32-unknown-none-elf -march=rv32i2p1_zicsr2p0_zifencei2p0 -mabi=ilp32"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv32"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv32im_zicsr_zifencei_ilp32
+    COMPILE_FLAGS "-march=rv32im_zicsr_zifencei -mabi=ilp32"
+    MULTILIB_FLAGS "--target=riscv32-unknown-none-elf -march=rv32i2p1_m2p0_zicsr2p0_zifencei2p0_zmmul1p0 -mabi=ilp32"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv32"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv32im_zicsr_zifencei_zba_zbb_zbc_zbs_ilp32
+    COMPILE_FLAGS "-march=rv32im_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=ilp32"
+    MULTILIB_FLAGS "--target=riscv32-unknown-none-elf -march=rv32i2p1_m2p0_zicsr2p0_zifencei2p0_zmmul1p0_zba1p0_zbb1p0_zbc1p0_zbs1p0 -mabi=ilp32"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv32"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv32imac_zicsr_zifencei_ilp32
+    COMPILE_FLAGS "-march=rv32imac_zicsr_zifencei -mabi=ilp32"
+    MULTILIB_FLAGS "--target=riscv32-unknown-none-elf -march=rv32i2p1_m2p0_a2p1_c2p0_zicsr2p0_zifencei2p0_zmmul1p0 -mabi=ilp32"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv32"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv32imafc_zicsr_zifencei_ilp32f
+    COMPILE_FLAGS "-march=rv32imafc_zicsr_zifencei -mabi=ilp32f"
+    MULTILIB_FLAGS "--target=riscv32-unknown-none-elf -march=rv32i2p1_m2p0_a2p1_f2p2_c2p0_zicsr2p0_zifencei2p0_zmmul1p0 -mabi=ilp32f"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv32"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv32imfc_zicsr_zifencei_ilp32f
+    COMPILE_FLAGS "-march=rv32imfc_zicsr_zifencei -mabi=ilp32f"
+    MULTILIB_FLAGS "--target=riscv32-unknown-none-elf -march=rv32i2p1_m2p0_f2p2_c2p0_zicsr2p0_zifencei2p0_zmmul1p0 -mabi=ilp32f"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv32"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv32imafd_zicsr_zifencei_ilp32d
+    COMPILE_FLAGS "-march=rv32imafd_zicsr_zifencei -mabi=ilp32d"
+    MULTILIB_FLAGS "--target=riscv32-unknown-none-elf -march=rv32i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0 -mabi=ilp32d"
+    PICOLIBC_BUILD_TYPE "release"
+    QEMU_MACHINE "none"
+    QEMU_CPU "rv32"
+    QEMU_PARAMS "-m 1G"
+    BOOT_FLASH_ADDRESS 0x00000000
+    BOOT_FLASH_SIZE 0x1000
+    FLASH_ADDRESS 0x20000000
+    FLASH_SIZE 0x1000000
+    RAM_ADDRESS 0x21000000
+    RAM_SIZE 0x1000000
+    STACK_SIZE 4K
+)
+add_library_variants_for_cpu(
+    rv32if_zicsr_zifencei_ilp32f
+    COMPILE_FLAGS "-march=rv32if_zicsr_zifencei -mabi=ilp32f"
+    MULTILIB_FLAGS "--target=riscv32-unknown-none-elf -march=rv32i2p1_f2p2_zicsr2p0_zifencei2p0 -mabi=ilp32f"
     PICOLIBC_BUILD_TYPE "release"
     QEMU_MACHINE "none"
     QEMU_CPU "rv32"

--- a/scripts/llvm/cmake/multilib.yaml.in
+++ b/scripts/llvm/cmake/multilib.yaml.in
@@ -245,3 +245,33 @@ Mappings:
 - Match: -march=rv32e([0-9]+p[0-9]+)_m([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)_zmmul([0-9]+p[0-9]+)_zba([0-9]+p[0-9]+)_zbb([0-9]+p[0-9]+)_zbc([0-9]+p[0-9]+)_zbs([0-9]+p[0-9]+)
   Flags:
   - -march=rv32e2p0_m2p0_c2p0_zicsr2p0_zifencei2p0_zmmul1p0_zba1p0_zbb1p0_zbc1p0_zbs1p0
+
+# RV64I alternate mappings
+## march.rv64i_zicsr_zifencei/mabi.lp64/mcmodel.medany=march.rv64ia_zicsr_zifencei/mabi.lp64/mcmodel.medany
+- Match: -march=rv64i([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv64i2p1_zicsr2p0_zifencei2p0
+## march.rv64i_zicsr_zifencei/mabi.lp64/mcmodel.medany=march.rv64iac_zicsr_zifencei/mabi.lp64/mcmodel.medany
+- Match: -march=rv64i([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv64i2p1_zicsr2p0_zifencei2p0
+## march.rv64i_zicsr_zifencei/mabi.lp64/mcmodel.medany=march.rv64ic_zicsr_zifencei/mabi.lp64/mcmodel.medany
+- Match: -march=rv64i([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv64i2p1_zicsr2p0_zifencei2p0
+## march.rv64im_zicsr_zifencei/mabi.lp64/mcmodel.medany=march.rv64ima_zicsr_zifencei/mabi.lp64/mcmodel.medany
+- Match: -march=rv64i([0-9]+p[0-9]+)_m([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)_zmmul([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv64i2p1_m2p0_zicsr2p0_zifencei2p0_zmmul1p0
+## march.rv64im_zicsr_zifencei/mabi.lp64/mcmodel.medany=march.rv64imc_zicsr_zifencei/mabi.lp64/mcmodel.medany
+- Match: -march=rv64i([0-9]+p[0-9]+)_m([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)_zmmul([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv64i2p1_m2p0_zicsr2p0_zifencei2p0_zmmul1p0
+## march.rv64im_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64/mcmodel.medany=march.rv64ima_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64/mcmodel.medany
+- Match: -march=rv64i([0-9]+p[0-9]+)_m([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)_zmmul([0-9]+p[0-9]+)_zba([0-9]+p[0-9]+)_zbb([0-9]+p[0-9]+)_zbc([0-9]+p[0-9]+)_zbs([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv64i2p1_m2p0_zicsr2p0_zifencei2p0_zmmul1p0_zba1p0_zbb1p0_zbc1p0_zbs1p0
+## march.rv64im_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64/mcmodel.medany=march.rv64imc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64/mcmodel.medany
+- Match: -march=rv64i([0-9]+p[0-9]+)_m([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)_zmmul([0-9]+p[0-9]+)_zba([0-9]+p[0-9]+)_zbb([0-9]+p[0-9]+)_zbc([0-9]+p[0-9]+)_zbs([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv64i2p1_m2p0_zicsr2p0_zifencei2p0_zmmul1p0_zba1p0_zbb1p0_zbc1p0_zbs1p0

--- a/scripts/llvm/cmake/multilib.yaml.in
+++ b/scripts/llvm/cmake/multilib.yaml.in
@@ -219,3 +219,29 @@ Mappings:
 - Match: -march=rv32i([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_f([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)
   Flags:
   - -march=rv32i2p1_f2p2_zicsr2p0_zifencei2p0
+
+# RV32E alternate mappings
+## march.rv32e_zicsr_zifencei/mabi.ilp32e=march.rv32ea_zicsr_zifencei/mabi.ilp32e
+- Match: -march=rv32e([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv32e2p0_zicsr2p0_zifencei2p0
+## march.rv32e_zicsr_zifencei/mabi.ilp32e=march.rv32eac_zicsr_zifencei/mabi.ilp32e
+- Match: -march=rv32e([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv32e2p0_zicsr2p0_zifencei2p0
+## march.rv32e_zicsr_zifencei/mabi.ilp32e=march.rv32ec_zicsr_zifencei/mabi.ilp32e
+- Match: -march=rv32e([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv32e2p0_zicsr2p0_zifencei2p0
+## march.rv32em_zicsr_zifencei/mabi.ilp32e=march.rv32ema_zicsr_zifencei/mabi.ilp32e
+- Match: -march=rv32e([0-9]+p[0-9]+)_m([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)_zmmul([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv32e2p0_m2p0_zicsr2p0_zifencei2p0_zmmul1p0
+## march.rv32emc_zicsr_zifencei/mabi.ilp32e=march.rv32emac_zicsr_zifencei/mabi.ilp32e
+- Match: -march=rv32e([0-9]+p[0-9]+)_m([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)_zmmul([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv32e2p0_m2p0_c2p0_zicsr2p0_zifencei2p0_zmmul1p0
+## march.rv32emc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.ilp32e=march.rv32emac_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.ilp32e
+- Match: -march=rv32e([0-9]+p[0-9]+)_m([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)_zmmul([0-9]+p[0-9]+)_zba([0-9]+p[0-9]+)_zbb([0-9]+p[0-9]+)_zbc([0-9]+p[0-9]+)_zbs([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv32e2p0_m2p0_c2p0_zicsr2p0_zifencei2p0_zmmul1p0_zba1p0_zbb1p0_zbc1p0_zbs1p0

--- a/scripts/llvm/cmake/multilib.yaml.in
+++ b/scripts/llvm/cmake/multilib.yaml.in
@@ -1,5 +1,7 @@
 #
 # Copyright (c) 2023, Arm Limited and affiliates.
+# Copyright (c) 2024 Stephanos Ioannidis <root@stephanos.io>
+#
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -171,3 +173,49 @@ Mappings:
 - Match: -march=thumbv8\.[1-9]m\.main(\+[^\+]+)*\+lob(\+[^\+]+)*
   Flags:
   - -march=thumbv8.1m.main+lob
+
+# RV32I alternate mappings
+## march.rv32i_zicsr_zifencei/mabi.ilp32=march.rv32ia_zicsr_zifencei/mabi.ilp32
+- Match: -march=rv32i([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv32i2p1_zicsr2p0_zifencei2p0
+## march.rv32i_zicsr_zifencei/mabi.ilp32=march.rv32iac_zicsr_zifencei/mabi.ilp32
+- Match: -march=rv32i([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv32i2p1_zicsr2p0_zifencei2p0
+## march.rv32i_zicsr_zifencei/mabi.ilp32=march.rv32iafc_zicsr_zifencei/mabi.ilp32
+- Match: -march=rv32i([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_f([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv32i2p1_zicsr2p0_zifencei2p0
+## march.rv32i_zicsr_zifencei/mabi.ilp32=march.rv32ic_zicsr_zifencei/mabi.ilp32
+- Match: -march=rv32i([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv32i2p1_zicsr2p0_zifencei2p0
+## march.rv32im_zicsr_zifencei/mabi.ilp32=march.rv32ima_zicsr_zifencei/mabi.ilp32
+- Match: -march=rv32i([0-9]+p[0-9]+)_m([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)_zmmul([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv32i2p1_m2p0_zicsr2p0_zifencei2p0_zmmul1p0
+## march.rv32im_zicsr_zifencei/mabi.ilp32=march.rv32imc_zicsr_zifencei/mabi.ilp32
+- Match: -march=rv32i([0-9]+p[0-9]+)_m([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)_zmmul([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv32i2p1_m2p0_zicsr2p0_zifencei2p0_zmmul1p0
+## march.rv32im_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.ilp32=march.rv32ima_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.ilp32
+- Match: -march=rv32i([0-9]+p[0-9]+)_m([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)_zmmul([0-9]+p[0-9]+)_zba([0-9]+p[0-9]+)_zbb([0-9]+p[0-9]+)_zbc([0-9]+p[0-9]+)_zbs([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv32i2p1_m2p0_zicsr2p0_zifencei2p0_zmmul1p0_zba1p0_zbb1p0_zbc1p0_zbs1p0
+## march.rv32im_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.ilp32=march.rv32imac_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.ilp32
+- Match: -march=rv32i([0-9]+p[0-9]+)_m([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)_zmmul([0-9]+p[0-9]+)_zba([0-9]+p[0-9]+)_zbb([0-9]+p[0-9]+)_zbc([0-9]+p[0-9]+)_zbs([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv32i2p1_m2p0_zicsr2p0_zifencei2p0_zmmul1p0_zba1p0_zbb1p0_zbc1p0_zbs1p0
+## march.rv32im_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.ilp32=march.rv32imc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.ilp32
+- Match: -march=rv32i([0-9]+p[0-9]+)_m([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)_zmmul([0-9]+p[0-9]+)_zba([0-9]+p[0-9]+)_zbb([0-9]+p[0-9]+)_zbc([0-9]+p[0-9]+)_zbs([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv32i2p1_m2p0_zicsr2p0_zifencei2p0_zmmul1p0_zba1p0_zbb1p0_zbc1p0_zbs1p0
+## march.rv32imafd_zicsr_zifencei/mabi.ilp32d=march.rv32imafdc_zicsr_zifencei/mabi.ilp32d
+- Match: -march=rv32i([0-9]+p[0-9]+)_m([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_f([0-9]+p[0-9]+)_d([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)_zmmul([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv32i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
+## march.rv32if_zicsr_zifencei/mabi.ilp32f=march.rv32iafc_zicsr_zifencei/mabi.ilp32f
+- Match: -march=rv32i([0-9]+p[0-9]+)_a([0-9]+p[0-9]+)_f([0-9]+p[0-9]+)_c([0-9]+p[0-9]+)_zicsr([0-9]+p[0-9]+)_zifencei([0-9]+p[0-9]+)
+  Flags:
+  - -march=rv32i2p1_f2p2_zicsr2p0_zifencei2p0

--- a/scripts/llvm/test-support/picolibc-test-wrapper.py
+++ b/scripts/llvm/test-support/picolibc-test-wrapper.py
@@ -13,9 +13,10 @@ import sys
 EXIT_CODE_SKIP = 77
 
 disabled_tests = [
-    # compiler-rt does not properly set floating point exceptions for
-    # computations on types implemented in software
+    # compiler-rt does not properly support floating point exceptions and
+    # rounding modes for computations on types implemented in software
     # https://github.com/picolibc/picolibc/pull/500
+    # https://github.com/zephyrproject-rtos/sdk-ng/issues/838
     "picolibc_armv7m_soft_fpv4_sp_d16-build/test/math_errhandling",
     "picolibc_armv7m_hard_fpv4_sp_d16-build/test/math_errhandling",
     "picolibc_armv7r_hard_vfpv3xd-build/test/math_errhandling",
@@ -30,6 +31,48 @@ disabled_tests = [
     "picolibc_armv8.1m.main_hard_nofp_mve_exn_rtti-build/test/fenv",
     "picolibc_armv8.1m.main_hard_nofp_mve_exn_rtti-build/test/math_errhandling",
     "picolibc_armv8m.main_hard_fp_exn_rtti-build/test/math_errhandling",
+    "picolibc_rv32imafc_zicsr_zifencei_ilp32f-build/test/rounding-mode",
+    "picolibc_rv32imafc_zicsr_zifencei_ilp32f-build/test/math_errhandling",
+    "picolibc_rv32imafc_zicsr_zifencei_ilp32f-build/test/test-fma",
+    "picolibc_rv32imafc_zicsr_zifencei_ilp32f_exn_rtti-build/test/rounding-mode",
+    "picolibc_rv32imafc_zicsr_zifencei_ilp32f_exn_rtti-build/test/math_errhandling",
+    "picolibc_rv32imafc_zicsr_zifencei_ilp32f_exn_rtti-build/test/test-fma",
+    "picolibc_rv32imfc_zicsr_zifencei_ilp32f-build/test/rounding-mode",
+    "picolibc_rv32imfc_zicsr_zifencei_ilp32f-build/test/math_errhandling",
+    "picolibc_rv32imfc_zicsr_zifencei_ilp32f-build/test/test-fma",
+    "picolibc_rv32imfc_zicsr_zifencei_ilp32f_exn_rtti-build/test/rounding-mode",
+    "picolibc_rv32imfc_zicsr_zifencei_ilp32f_exn_rtti-build/test/math_errhandling",
+    "picolibc_rv32imfc_zicsr_zifencei_ilp32f_exn_rtti-build/test/test-fma",
+    "picolibc_rv32imafd_zicsr_zifencei_ilp32d-build/test/math_errhandling",
+    "picolibc_rv32imafd_zicsr_zifencei_ilp32d-build/test/test-fma",
+    "picolibc_rv32imafd_zicsr_zifencei_ilp32d_exn_rtti-build/test/math_errhandling",
+    "picolibc_rv32imafd_zicsr_zifencei_ilp32d_exn_rtti-build/test/test-fma",
+    "picolibc_rv32if_zicsr_zifencei_ilp32f-build/test/rounding-mode",
+    "picolibc_rv32if_zicsr_zifencei_ilp32f-build/test/math_errhandling",
+    "picolibc_rv32if_zicsr_zifencei_ilp32f-build/test/test-fma",
+    "picolibc_rv32if_zicsr_zifencei_ilp32f_exn_rtti-build/test/rounding-mode",
+    "picolibc_rv32if_zicsr_zifencei_ilp32f_exn_rtti-build/test/math_errhandling",
+    "picolibc_rv32if_zicsr_zifencei_ilp32f_exn_rtti-build/test/test-fma",
+    "picolibc_rv64imafdc_zicsr_zifencei_lp64d-build/test/math_errhandling",
+    "picolibc_rv64imafdc_zicsr_zifencei_lp64d-build/test/test-fma",
+    "picolibc_rv64imafdc_zicsr_zifencei_lp64d_exn_rtti-build/test/math_errhandling",
+    "picolibc_rv64imafdc_zicsr_zifencei_lp64d_exn_rtti-build/test/test-fma",
+    "picolibc_rv64imafd_zicsr_zifencei_lp64d-build/test/math_errhandling",
+    "picolibc_rv64imafd_zicsr_zifencei_lp64d-build/test/test-fma",
+    "picolibc_rv64imafd_zicsr_zifencei_lp64d_exn_rtti-build/test/math_errhandling",
+    "picolibc_rv64imafd_zicsr_zifencei_lp64d_exn_rtti-build/test/test-fma",
+    "picolibc_rv64imfc_zicsr_zifencei_lp64f-build/test/rounding-mode",
+    "picolibc_rv64imfc_zicsr_zifencei_lp64f-build/test/math_errhandling",
+    "picolibc_rv64imfc_zicsr_zifencei_lp64f-build/test/test-fma",
+    "picolibc_rv64imfc_zicsr_zifencei_lp64f_exn_rtti-build/test/rounding-mode",
+    "picolibc_rv64imfc_zicsr_zifencei_lp64f_exn_rtti-build/test/math_errhandling",
+    "picolibc_rv64imfc_zicsr_zifencei_lp64f_exn_rtti-build/test/test-fma",
+    "picolibc_rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs_lp64f-build/test/rounding-mode",
+    "picolibc_rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs_lp64f-build/test/math_errhandling",
+    "picolibc_rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs_lp64f-build/test/test-fma",
+    "picolibc_rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs_lp64f_exn_rtti-build/test/rounding-mode",
+    "picolibc_rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs_lp64f_exn_rtti-build/test/math_errhandling",
+    "picolibc_rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs_lp64f_exn_rtti-build/test/test-fma",
 ]
 
 

--- a/scripts/llvm/test/multilib/rv32e.test
+++ b/scripts/llvm/test/multilib/rv32e.test
@@ -1,16 +1,22 @@
 # RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32e_zicsr_zifencei -mabi=ilp32e | FileCheck %s --check-prefix=RV32E_ZICSR_ZIFENCEI_ILP32E
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32ea_zicsr_zifencei -mabi=ilp32e | FileCheck %s --check-prefix=RV32E_ZICSR_ZIFENCEI_ILP32E
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32eac_zicsr_zifencei -mabi=ilp32e | FileCheck %s --check-prefix=RV32E_ZICSR_ZIFENCEI_ILP32E
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32ec_zicsr_zifencei -mabi=ilp32e | FileCheck %s --check-prefix=RV32E_ZICSR_ZIFENCEI_ILP32E
 # RV32E_ZICSR_ZIFENCEI_ILP32E: riscv32-none-elf/rv32e_zicsr_zifencei_ilp32e_exn_rtti{{$}}
 # RV32E_ZICSR_ZIFENCEI_ILP32E-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32em_zicsr_zifencei -mabi=ilp32e | FileCheck %s --check-prefix=RV32EM_ZICSR_ZIFENCEI_ILP32E
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32ema_zicsr_zifencei -mabi=ilp32e | FileCheck %s --check-prefix=RV32EM_ZICSR_ZIFENCEI_ILP32E
 # RV32EM_ZICSR_ZIFENCEI_ILP32E: riscv32-none-elf/rv32em_zicsr_zifencei_ilp32e_exn_rtti{{$}}
 # RV32EM_ZICSR_ZIFENCEI_ILP32E-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32emc_zicsr_zifencei -mabi=ilp32e | FileCheck %s --check-prefix=RV32EMC_ZICSR_ZIFENCEI_ILP32E
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32emac_zicsr_zifencei -mabi=ilp32e | FileCheck %s --check-prefix=RV32EMC_ZICSR_ZIFENCEI_ILP32E
 # RV32EMC_ZICSR_ZIFENCEI_ILP32E: riscv32-none-elf/rv32emc_zicsr_zifencei_ilp32e_exn_rtti{{$}}
 # RV32EMC_ZICSR_ZIFENCEI_ILP32E-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32emc_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=ilp32e | FileCheck %s --check-prefix=RV32EMC_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_ILP32E
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32emac_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=ilp32e | FileCheck %s --check-prefix=RV32EMC_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_ILP32E
 # RV32EMC_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_ILP32E: riscv32-none-elf/rv32emc_zicsr_zifencei_zba_zbb_zbc_zbs_ilp32e_exn_rtti{{$}}
 # RV32EMC_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_ILP32E-EMPTY:
 

--- a/scripts/llvm/test/multilib/rv32e.test
+++ b/scripts/llvm/test/multilib/rv32e.test
@@ -1,0 +1,23 @@
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32e_zicsr_zifencei -mabi=ilp32e | FileCheck %s --check-prefix=RV32E_ZICSR_ZIFENCEI_ILP32E
+# RV32E_ZICSR_ZIFENCEI_ILP32E: riscv32-none-elf/rv32e_zicsr_zifencei_ilp32e_exn_rtti{{$}}
+# RV32E_ZICSR_ZIFENCEI_ILP32E-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32em_zicsr_zifencei -mabi=ilp32e | FileCheck %s --check-prefix=RV32EM_ZICSR_ZIFENCEI_ILP32E
+# RV32EM_ZICSR_ZIFENCEI_ILP32E: riscv32-none-elf/rv32em_zicsr_zifencei_ilp32e_exn_rtti{{$}}
+# RV32EM_ZICSR_ZIFENCEI_ILP32E-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32emc_zicsr_zifencei -mabi=ilp32e | FileCheck %s --check-prefix=RV32EMC_ZICSR_ZIFENCEI_ILP32E
+# RV32EMC_ZICSR_ZIFENCEI_ILP32E: riscv32-none-elf/rv32emc_zicsr_zifencei_ilp32e_exn_rtti{{$}}
+# RV32EMC_ZICSR_ZIFENCEI_ILP32E-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32emc_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=ilp32e | FileCheck %s --check-prefix=RV32EMC_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_ILP32E
+# RV32EMC_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_ILP32E: riscv32-none-elf/rv32emc_zicsr_zifencei_zba_zbb_zbc_zbs_ilp32e_exn_rtti{{$}}
+# RV32EMC_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_ILP32E-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32emc_zicsr -mabi=ilp32e | FileCheck %s --check-prefix=RV32EMC_ZICSR_ILP32E
+# RV32EMC_ZICSR_ILP32E: riscv32-none-elf/rv32emc_zicsr_ilp32e_exn_rtti{{$}}
+# RV32EMC_ZICSR_ILP32E-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32emc_zicsr_zba_zbb_zbc_zbs -mabi=ilp32e | FileCheck %s --check-prefix=RV32EMC_ZICSR_ZBA_ZBB_ZBC_ZBS_ILP32E
+# RV32EMC_ZICSR_ZBA_ZBB_ZBC_ZBS_ILP32E: riscv32-none-elf/rv32emc_zicsr_zba_zbb_zbc_zbs_ilp32e_exn_rtti{{$}}
+# RV32EMC_ZICSR_ZBA_ZBB_ZBC_ZBS_ILP32E-EMPTY:

--- a/scripts/llvm/test/multilib/rv32i.test
+++ b/scripts/llvm/test/multilib/rv32i.test
@@ -1,12 +1,21 @@
 # RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32i_zicsr_zifencei -mabi=ilp32 | FileCheck %s --check-prefix=RV32I_ZICSR_ZIFENCEI_ILP32
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32ia_zicsr_zifencei -mabi=ilp32 | FileCheck %s --check-prefix=RV32I_ZICSR_ZIFENCEI_ILP32
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32iac_zicsr_zifencei -mabi=ilp32 | FileCheck %s --check-prefix=RV32I_ZICSR_ZIFENCEI_ILP32
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32iafc_zicsr_zifencei -mabi=ilp32 | FileCheck %s --check-prefix=RV32I_ZICSR_ZIFENCEI_ILP32
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32ic_zicsr_zifencei -mabi=ilp32 | FileCheck %s --check-prefix=RV32I_ZICSR_ZIFENCEI_ILP32
 # RV32I_ZICSR_ZIFENCEI_ILP32: riscv32-none-elf/rv32i_zicsr_zifencei_ilp32_exn_rtti{{$}}
 # RV32I_ZICSR_ZIFENCEI_ILP32-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32im_zicsr_zifencei -mabi=ilp32 | FileCheck %s --check-prefix=RV32IM_ZICSR_ZIFENCEI_ILP32
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32ima_zicsr_zifencei -mabi=ilp32 | FileCheck %s --check-prefix=RV32IM_ZICSR_ZIFENCEI_ILP32
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32imc_zicsr_zifencei -mabi=ilp32 | FileCheck %s --check-prefix=RV32IM_ZICSR_ZIFENCEI_ILP32
 # RV32IM_ZICSR_ZIFENCEI_ILP32: riscv32-none-elf/rv32im_zicsr_zifencei_ilp32_exn_rtti{{$}}
 # RV32IM_ZICSR_ZIFENCEI_ILP32-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32im_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=ilp32 | FileCheck %s --check-prefix=RV32IM_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_ILP32
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32ima_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=ilp32 | FileCheck %s --check-prefix=RV32IM_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_ILP32
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32imac_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=ilp32 | FileCheck %s --check-prefix=RV32IM_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_ILP32
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32imc_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=ilp32 | FileCheck %s --check-prefix=RV32IM_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_ILP32
 # RV32IM_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_ILP32: riscv32-none-elf/rv32im_zicsr_zifencei_zba_zbb_zbc_zbs_ilp32_exn_rtti{{$}}
 # RV32IM_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_ILP32-EMPTY:
 
@@ -23,9 +32,13 @@
 # RV32IMFC_ZICSR_ZIFENCEI_ILP32F-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32imafd_zicsr_zifencei -mabi=ilp32d | FileCheck %s --check-prefix=RV32IMAFD_ZICSR_ZIFENCEI_ILP32D
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32imafdc_zicsr_zifencei -mabi=ilp32d | FileCheck %s --check-prefix=RV32IMAFD_ZICSR_ZIFENCEI_ILP32D
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32g -mabi=ilp32d | FileCheck %s --check-prefix=RV32IMAFD_ZICSR_ZIFENCEI_ILP32D
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32gc -mabi=ilp32d | FileCheck %s --check-prefix=RV32IMAFD_ZICSR_ZIFENCEI_ILP32D
 # RV32IMAFD_ZICSR_ZIFENCEI_ILP32D: riscv32-none-elf/rv32imafd_zicsr_zifencei_ilp32d_exn_rtti{{$}}
 # RV32IMAFD_ZICSR_ZIFENCEI_ILP32D-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32if_zicsr_zifencei -mabi=ilp32f | FileCheck %s --check-prefix=RV32IF_ZICSR_ZIFENCEI_ILP32F
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32iafc_zicsr_zifencei -mabi=ilp32f | FileCheck %s --check-prefix=RV32IF_ZICSR_ZIFENCEI_ILP32F
 # RV32IF_ZICSR_ZIFENCEI_ILP32F: riscv32-none-elf/rv32if_zicsr_zifencei_ilp32f_exn_rtti{{$}}
 # RV32IF_ZICSR_ZIFENCEI_ILP32F-EMPTY:

--- a/scripts/llvm/test/multilib/rv32i.test
+++ b/scripts/llvm/test/multilib/rv32i.test
@@ -1,0 +1,31 @@
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32i_zicsr_zifencei -mabi=ilp32 | FileCheck %s --check-prefix=RV32I_ZICSR_ZIFENCEI_ILP32
+# RV32I_ZICSR_ZIFENCEI_ILP32: riscv32-none-elf/rv32i_zicsr_zifencei_ilp32_exn_rtti{{$}}
+# RV32I_ZICSR_ZIFENCEI_ILP32-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32im_zicsr_zifencei -mabi=ilp32 | FileCheck %s --check-prefix=RV32IM_ZICSR_ZIFENCEI_ILP32
+# RV32IM_ZICSR_ZIFENCEI_ILP32: riscv32-none-elf/rv32im_zicsr_zifencei_ilp32_exn_rtti{{$}}
+# RV32IM_ZICSR_ZIFENCEI_ILP32-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32im_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=ilp32 | FileCheck %s --check-prefix=RV32IM_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_ILP32
+# RV32IM_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_ILP32: riscv32-none-elf/rv32im_zicsr_zifencei_zba_zbb_zbc_zbs_ilp32_exn_rtti{{$}}
+# RV32IM_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_ILP32-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32imac_zicsr_zifencei -mabi=ilp32 | FileCheck %s --check-prefix=RV32IMAC_ZICSR_ZIFENCEI_ILP32
+# RV32IMAC_ZICSR_ZIFENCEI_ILP32: riscv32-none-elf/rv32imac_zicsr_zifencei_ilp32_exn_rtti{{$}}
+# RV32IMAC_ZICSR_ZIFENCEI_ILP32-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32imafc_zicsr_zifencei -mabi=ilp32f | FileCheck %s --check-prefix=RV32IMAFC_ZICSR_ZIFENCEI_ILP32F
+# RV32IMAFC_ZICSR_ZIFENCEI_ILP32F: riscv32-none-elf/rv32imafc_zicsr_zifencei_ilp32f_exn_rtti{{$}}
+# RV32IMAFC_ZICSR_ZIFENCEI_ILP32F-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32imfc_zicsr_zifencei -mabi=ilp32f | FileCheck %s --check-prefix=RV32IMFC_ZICSR_ZIFENCEI_ILP32F
+# RV32IMFC_ZICSR_ZIFENCEI_ILP32F: riscv32-none-elf/rv32imfc_zicsr_zifencei_ilp32f_exn_rtti{{$}}
+# RV32IMFC_ZICSR_ZIFENCEI_ILP32F-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32imafd_zicsr_zifencei -mabi=ilp32d | FileCheck %s --check-prefix=RV32IMAFD_ZICSR_ZIFENCEI_ILP32D
+# RV32IMAFD_ZICSR_ZIFENCEI_ILP32D: riscv32-none-elf/rv32imafd_zicsr_zifencei_ilp32d_exn_rtti{{$}}
+# RV32IMAFD_ZICSR_ZIFENCEI_ILP32D-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv32-none-elf -march=rv32if_zicsr_zifencei -mabi=ilp32f | FileCheck %s --check-prefix=RV32IF_ZICSR_ZIFENCEI_ILP32F
+# RV32IF_ZICSR_ZIFENCEI_ILP32F: riscv32-none-elf/rv32if_zicsr_zifencei_ilp32f_exn_rtti{{$}}
+# RV32IF_ZICSR_ZIFENCEI_ILP32F-EMPTY:

--- a/scripts/llvm/test/multilib/rv64i.test
+++ b/scripts/llvm/test/multilib/rv64i.test
@@ -1,12 +1,19 @@
 # RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64i_zicsr_zifencei -mabi=lp64 | FileCheck %s --check-prefix=RV64I_ZICSR_ZIFENCEI_LP64
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64ia_zicsr_zifencei -mabi=lp64 | FileCheck %s --check-prefix=RV64I_ZICSR_ZIFENCEI_LP64
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64iac_zicsr_zifencei -mabi=lp64 | FileCheck %s --check-prefix=RV64I_ZICSR_ZIFENCEI_LP64
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64ic_zicsr_zifencei -mabi=lp64 | FileCheck %s --check-prefix=RV64I_ZICSR_ZIFENCEI_LP64
 # RV64I_ZICSR_ZIFENCEI_LP64: riscv64-none-elf/rv64i_zicsr_zifencei_lp64_exn_rtti{{$}}
 # RV64I_ZICSR_ZIFENCEI_LP64-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64im_zicsr_zifencei -mabi=lp64 | FileCheck %s --check-prefix=RV64IM_ZICSR_ZIFENCEI_LP64
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64ima_zicsr_zifencei -mabi=lp64 | FileCheck %s --check-prefix=RV64IM_ZICSR_ZIFENCEI_LP64
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64imc_zicsr_zifencei -mabi=lp64 | FileCheck %s --check-prefix=RV64IM_ZICSR_ZIFENCEI_LP64
 # RV64IM_ZICSR_ZIFENCEI_LP64: riscv64-none-elf/rv64im_zicsr_zifencei_lp64_exn_rtti{{$}}
 # RV64IM_ZICSR_ZIFENCEI_LP64-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64im_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=lp64 | FileCheck %s --check-prefix=RV64IM_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_LP64
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64ima_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=lp64 | FileCheck %s --check-prefix=RV64IM_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_LP64
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64imc_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=lp64 | FileCheck %s --check-prefix=RV64IM_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_LP64
 # RV64IM_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_LP64: riscv64-none-elf/rv64im_zicsr_zifencei_zba_zbb_zbc_zbs_lp64_exn_rtti{{$}}
 # RV64IM_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_LP64-EMPTY:
 
@@ -19,10 +26,12 @@
 # RV64IMAC_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_LP64-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64imafdc_zicsr_zifencei -mabi=lp64d | FileCheck %s --check-prefix=RV64IMAFDC_ZICSR_ZIFENCEI_LP64D
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64gc -mabi=lp64d | FileCheck %s --check-prefix=RV64IMAFDC_ZICSR_ZIFENCEI_LP64D
 # RV64IMAFDC_ZICSR_ZIFENCEI_LP64D: riscv64-none-elf/rv64imafdc_zicsr_zifencei_lp64d_exn_rtti{{$}}
 # RV64IMAFDC_ZICSR_ZIFENCEI_LP64D-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64imafd_zicsr_zifencei -mabi=lp64d | FileCheck %s --check-prefix=RV64IMAFD_ZICSR_ZIFENCEI_LP64D
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64g -mabi=lp64d | FileCheck %s --check-prefix=RV64IMAFD_ZICSR_ZIFENCEI_LP64D
 # RV64IMAFD_ZICSR_ZIFENCEI_LP64D: riscv64-none-elf/rv64imafd_zicsr_zifencei_lp64d_exn_rtti{{$}}
 # RV64IMAFD_ZICSR_ZIFENCEI_LP64D-EMPTY:
 

--- a/scripts/llvm/test/multilib/rv64i.test
+++ b/scripts/llvm/test/multilib/rv64i.test
@@ -1,0 +1,35 @@
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64i_zicsr_zifencei -mabi=lp64 | FileCheck %s --check-prefix=RV64I_ZICSR_ZIFENCEI_LP64
+# RV64I_ZICSR_ZIFENCEI_LP64: riscv64-none-elf/rv64i_zicsr_zifencei_lp64_exn_rtti{{$}}
+# RV64I_ZICSR_ZIFENCEI_LP64-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64im_zicsr_zifencei -mabi=lp64 | FileCheck %s --check-prefix=RV64IM_ZICSR_ZIFENCEI_LP64
+# RV64IM_ZICSR_ZIFENCEI_LP64: riscv64-none-elf/rv64im_zicsr_zifencei_lp64_exn_rtti{{$}}
+# RV64IM_ZICSR_ZIFENCEI_LP64-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64im_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=lp64 | FileCheck %s --check-prefix=RV64IM_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_LP64
+# RV64IM_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_LP64: riscv64-none-elf/rv64im_zicsr_zifencei_zba_zbb_zbc_zbs_lp64_exn_rtti{{$}}
+# RV64IM_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_LP64-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64imac_zicsr_zifencei -mabi=lp64 | FileCheck %s --check-prefix=RV64IMAC_ZICSR_ZIFENCEI_LP64
+# RV64IMAC_ZICSR_ZIFENCEI_LP64: riscv64-none-elf/rv64imac_zicsr_zifencei_lp64_exn_rtti{{$}}
+# RV64IMAC_ZICSR_ZIFENCEI_LP64-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64imac_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=lp64 | FileCheck %s --check-prefix=RV64IMAC_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_LP64
+# RV64IMAC_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_LP64: riscv64-none-elf/rv64imac_zicsr_zifencei_zba_zbb_zbc_zbs_lp64_exn_rtti{{$}}
+# RV64IMAC_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_LP64-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64imafdc_zicsr_zifencei -mabi=lp64d | FileCheck %s --check-prefix=RV64IMAFDC_ZICSR_ZIFENCEI_LP64D
+# RV64IMAFDC_ZICSR_ZIFENCEI_LP64D: riscv64-none-elf/rv64imafdc_zicsr_zifencei_lp64d_exn_rtti{{$}}
+# RV64IMAFDC_ZICSR_ZIFENCEI_LP64D-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64imafd_zicsr_zifencei -mabi=lp64d | FileCheck %s --check-prefix=RV64IMAFD_ZICSR_ZIFENCEI_LP64D
+# RV64IMAFD_ZICSR_ZIFENCEI_LP64D: riscv64-none-elf/rv64imafd_zicsr_zifencei_lp64d_exn_rtti{{$}}
+# RV64IMAFD_ZICSR_ZIFENCEI_LP64D-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64imfc_zicsr_zifencei -mabi=lp64f | FileCheck %s --check-prefix=RV64IMFC_ZICSR_ZIFENCEI_LP64F
+# RV64IMFC_ZICSR_ZIFENCEI_LP64F: riscv64-none-elf/rv64imfc_zicsr_zifencei_lp64f_exn_rtti{{$}}
+# RV64IMFC_ZICSR_ZIFENCEI_LP64F-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv64-none-elf -march=rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs -mabi=lp64f | FileCheck %s --check-prefix=RV64IMFC_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_LP64F
+# RV64IMFC_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_LP64F: riscv64-none-elf/rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs_lp64f_exn_rtti{{$}}
+# RV64IMFC_ZICSR_ZIFENCEI_ZBA_ZBB_ZBC_ZBS_LP64F-EMPTY:


### PR DESCRIPTION
Add RV32I, RV32E and RV64I "common" multi-libs, based on [the list of Zephyr GCC RISC-V multi-libs](https://github.com/zephyrproject-rtos/gcc/blob/e8b0df3247f3b915f50f2233c8170009e33cde84/gcc/config/riscv/t-zephyr#L64-L87).