### PR TITLE
ci: Add RISC-V platforms for LLVM testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1769,7 +1769,8 @@ jobs:
           # FIXME: There are issues building some tests for qemu_riscv32.
           # PLATFORM_ARGS+="-p qemu_riscv32 "
           ## RV32E
-          PLATFORM_ARGS+="-p qemu_riscv32e "
+          # FIXME: There are issues building some tests for qemu_riscv32e.
+          # PLATFORM_ARGS+="-p qemu_riscv32e "
           ## RV64I
           PLATFORM_ARGS+="-p qemu_riscv64 "
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1765,9 +1765,12 @@ jobs:
           # PLATFORM_ARGS+="-p mps3/an547 "
 
           # Add RISC-V platforms
-          ## TODO: Add RV32I platforms
-          ## TODO: Add RV32E platforms
-          ## TODO: Add RV64I platforms
+          ## RV32I
+          PLATFORM_ARGS+="-p qemu_riscv32 "
+          ## RV32E
+          PLATFORM_ARGS+="-p qemu_riscv32e "
+          ## RV64I
+          PLATFORM_ARGS+="-p qemu_riscv64 "
         fi
 
         # Generate test list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1772,7 +1772,8 @@ jobs:
           # FIXME: There are issues building some tests for qemu_riscv32e.
           # PLATFORM_ARGS+="-p qemu_riscv32e "
           ## RV64I
-          PLATFORM_ARGS+="-p qemu_riscv64 "
+          # FIXME: There are issues building some tests for qemu_riscv64.
+          # PLATFORM_ARGS+="-p qemu_riscv64 "
         fi
 
         # Generate test list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1766,7 +1766,8 @@ jobs:
 
           # Add RISC-V platforms
           ## RV32I
-          PLATFORM_ARGS+="-p qemu_riscv32 "
+          # FIXME: There are issues building some tests for qemu_riscv32.
+          # PLATFORM_ARGS+="-p qemu_riscv32 "
           ## RV32E
           PLATFORM_ARGS+="-p qemu_riscv32e "
           ## RV64I


### PR DESCRIPTION
Add RISC-V platforms for LLVM testing, and disable them for now until they are fixed on the Zephyr side.