### PR TITLE
picolib: Add stdc++ noexcept variant

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "crosstool-ng"]
 	path = crosstool-ng
-	url = https://github.com/zephyrproject-rtos/crosstool-ng.git
+	url = https://github.com/adigie/crosstool-ng.git
 [submodule "binutils"]
 	path = binutils
 	url = https://github.com/zephyrproject-rtos/binutils-gdb.git

--- a/cmake/zephyr/generic.cmake
+++ b/cmake/zephyr/generic.cmake
@@ -31,3 +31,4 @@ set(CROSS_COMPILE ${one_toolchain_root}/${CROSS_COMPILE_TARGET}/bin/${CROSS_COMP
 set(SYSROOT_DIR   ${one_toolchain_root}/${SYSROOT_TARGET}/${SYSROOT_TARGET})
 set(TOOLCHAIN_HAS_NEWLIB ON CACHE BOOL "True if toolchain supports newlib")
 set(TOOLCHAIN_HAS_PICOLIBC ON CACHE BOOL "True if toolchain supports picolibc")
+set(TOOLCHAIN_HAS_PICOLIBC_NOEXCEPT ON CACHE BOOL "True if toolchain supports picolibc variant with exceptions disabled")


### PR DESCRIPTION
Compile additional variant of libstdc++ with exceptions disabled.

crosstool-ng PR: zephyrproject-rtos/crosstool-ng/pull/32
Fixes #860