### PR TITLE
cmake: llvm: fix --config param

### DIFF
--- a/cmake/zephyr/llvm/target.cmake
+++ b/cmake/zephyr/llvm/target.cmake
@@ -37,7 +37,5 @@ if(DEFINED triple)
   unset(triple)
 endif()
 
-list(APPEND TOOLCHAIN_C_FLAGS --config
-	${ZEPHYR_SDK_INSTALL_DIR}/cmake/zephyr/llvm/clang_compiler_rt.cfg)
-list(APPEND TOOLCHAIN_LD_FLAGS --config
-	${ZEPHYR_SDK_INSTALL_DIR}/cmake/zephyr/llvm/clang_compiler_rt.cfg)
+list(APPEND TOOLCHAIN_C_FLAGS "--config=${ZEPHYR_SDK_INSTALL_DIR}/cmake/zephyr/llvm/clang_compiler_rt.cfg")
+list(APPEND TOOLCHAIN_LD_FLAGS "--config=${ZEPHYR_SDK_INSTALL_DIR}/cmake/zephyr/llvm/clang_compiler_rt.cfg")


### PR DESCRIPTION
This fixes 'error: unknown argument: '--config/home/ncs/toolchains/86896046f0/opt/zephyr-sdk/cmake/zephyr/llvm/clang_compiler_rt.cfg

Signed-off-by: Sebastian Wezel <sebastian.wezel@nordicsemi.no>
