### PR TITLE
picolibc: Disable exceptions for picolibc libstdc++

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "crosstool-ng"]
 	path = crosstool-ng
-	url = https://github.com/zephyrproject-rtos/crosstool-ng.git
+	url = https://github.com/adigie/crosstool-ng.git
 [submodule "binutils"]
 	path = binutils
 	url = https://github.com/zephyrproject-rtos/binutils-gdb.git


### PR DESCRIPTION
Picolibc is targeted for smaller embedded systems. It brings improvement over newlib-nano in case of pure C applications. However when used with C++ applications all gains from smaller size of libc are wasted by exception handling support in libstdc++.

This change disables exception support in picolibc libstdc++. It results in decreased flash usage - ~9.5kB for ARM target.

crosstool-ng PR: https://github.com/zephyrproject-rtos/crosstool-ng/pull/33
Fixes #860