### PR TITLE
Revert "overlays/mtk: Fix linker API"

### DIFF
--- a/overlays/xtensa_mtk_mt818x_adsp/gdb/gdb/xtensa-config.c
+++ b/overlays/xtensa_mtk_mt818x_adsp/gdb/gdb/xtensa-config.c
@@ -555,9 +555,7 @@ xtensa_register_t rmap[] =
   XTREG_END
 };
 
-extern xtensa_register_t xtensa_rmap[] __attribute__((alias("rmap")));
 
-xtensa_gdbarch_tdep xtensa_tdep (rmap);
 
 #ifdef XTENSA_CONFIG_INSTANTIATE
 XTENSA_CONFIG_INSTANTIATE(rmap,16)

--- a/overlays/xtensa_mtk_mt8195_adsp/gdb/gdb/xtensa-config.c
+++ b/overlays/xtensa_mtk_mt8195_adsp/gdb/gdb/xtensa-config.c
@@ -113,7 +113,7 @@ const xtensa_mask_t xtensa_mask39 = { 1, xtensa_submask39 };
 
 
 /* Register map.  */
-xtensa_register_t rmap[] =
+static xtensa_register_t rmap[] =
 {
   /*    idx ofs bi sz al targno  flags cp typ group name  */
   XTREG(  0,  0,32, 4, 4,0x0020,0x0006,-2, 9,0x2100,pc,          0,0,0,0,0,0)
@@ -495,7 +495,5 @@ xtensa_register_t rmap[] =
             0,0,&xtensa_mask38,0,0,0)
   XTREG_END
 };
-
-extern xtensa_register_t xtensa_rmap[] __attribute__((alias("rmap")));
 
 xtensa_gdbarch_tdep xtensa_tdep (rmap);

--- a/overlays/xtensa_mtk_mt8196_adsp/gdb/gdb/xtensa-config.c
+++ b/overlays/xtensa_mtk_mt8196_adsp/gdb/gdb/xtensa-config.c
@@ -555,9 +555,7 @@ xtensa_register_t rmap[] =
   XTREG_END
 };
 
-extern xtensa_register_t xtensa_rmap[] __attribute__((alias("rmap")));
 
-xtensa_gdbarch_tdep xtensa_tdep (rmap);
 
 #ifdef XTENSA_CONFIG_INSTANTIATE
 XTENSA_CONFIG_INSTANTIATE(rmap,16)


### PR DESCRIPTION
This reverts commit fff09281116059d051de84bc0afcd9500bbbfa47.

This change is cause build issues on Darwin and is not needed and not
compatible with current crosstools-ng.
Will be re-added once we have a more up to date ctng.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
