### PR TITLE
qemu: install ivshmem-server/ivshmem-client

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/qemu/qemu-zephyr_9.2.1.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/qemu-zephyr_9.2.1.bb
@@ -133,6 +133,8 @@ do_configure[cleandirs] += "${B}"
 do_install () {
 	export STRIP=""
 	oe_runmake 'DESTDIR=${D}' install
+        install -m 0755 ${WORKDIR}/build/contrib/ivshmem-server/ivshmem-server ${D}${bindir}
+        install -m 0755 ${WORKDIR}/build/contrib/ivshmem-client/ivshmem-client ${D}${bindir}
 
 	# If we built the guest agent, also install startup/udev rules
 	if [ -e "${D}${bindir}/qemu-ga" ]; then


### PR DESCRIPTION
Those are needed for testing ipc/ipm in zephyr.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
