### PR TITLE
ci: rename intel_adsp/ace30_ptl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1592,7 +1592,7 @@ jobs:
               PLATFORM_ARGS+="-p intel_adsp/ace15_mtpm "
               ;;
             xtensa-intel_ace30_ptl_zephyr-elf)
-              PLATFORM_ARGS+="-p intel_adsp/ace30_ptl "
+              PLATFORM_ARGS+="-p intel_adsp/ace30/ptl "
               ;;
             xtensa-intel_tgl_adsp_zephyr-elf)
               PLATFORM_ARGS+="-p intel_adsp/cavs25 "


### PR DESCRIPTION
Target is called intel_adsp/ace30/ptl now.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
