### PR TITLE
microblazeel: Re-enable picolibc

### DIFF
--- a/configs/microblazeel-zephyr-elf.config
+++ b/configs/microblazeel-zephyr-elf.config
@@ -5,6 +5,3 @@ CT_ARCH_LE=y
 CT_TARGET_CFLAGS="-G0 -fno-pic"
 CT_TARGET_VENDOR="zephyr"
 CT_MULTILIB=y
-# FIXME: Picolibc is disabled for microblazeel due to build failure
-#        (see GitHub issue #639).
-CT_COMP_LIBS_PICOLIBC=n


### PR DESCRIPTION
Picolibc has had microblazeel support since version 1.8.2, which was released about two years ago.

Fixes: #639 