### PR TITLE
meta-zephyr-sdk: xilinx_qemu: Enable slirp

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/qemu/qemu-zephyr_9.2.1.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/qemu-zephyr_9.2.1.bb
@@ -10,7 +10,7 @@ a variety of guest operating systems"
 HOMEPAGE = "http://qemu.org"
 LICENSE = "GPL-2.0-only & LGPL-2.1-only"
 
-DEPENDS += "bison-native meson-native ninja-native"
+DEPENDS += "bison-native meson-native ninja-native libslirp"
 
 DEPENDS += "glib-2.0 zlib pixman"
 

--- a/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/qemu-xilinx_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/qemu-xilinx_git.bb
@@ -1,4 +1,4 @@
-DEPENDS = "glib-2.0 zlib dtc pixman bison-native meson-native ninja-native libgcrypt"
+DEPENDS = "glib-2.0 zlib dtc pixman bison-native meson-native ninja-native libgcrypt libslirp"
 LICENSE = "GPL-2.0-only & LGPL-2.1-only"
 
 RDEPENDS:${PN}-common:class-target += "bash"
@@ -57,6 +57,7 @@ EXTRA_OECONF = " \
   --disable-curl --disable-attr --disable-curses --disable-iconv \
   --disable-kvm --disable-parallels --disable-replication \
   --disable-live-block-migration --disable-dmg --disable-werror \
+  --enable-slirp \
   "
 
 QEMU_TARGETS = "aarch64-softmmu riscv32-softmmu riscv64-softmmu microblazeel-softmmu"


### PR DESCRIPTION
Enable user-space TCP/IP stack for network emulation to be able to connect emulated ethernet controllers with host PC for testing purpose.