### PR TITLE
ci: rename esp32_devkitc_wroom/esp32/procpu -> esp32_devkitc/esp32/procpu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1587,7 +1587,7 @@ jobs:
               PLATFORM_ARGS+="-p qemu_xtensa/dc233c/mmu "
               ;;
             xtensa-espressif_esp32_zephyr-elf)
-              PLATFORM_ARGS+="-p esp32_devkitc_wroom/esp32/procpu "
+              PLATFORM_ARGS+="-p esp32_devkitc/esp32/procpu "
               ;;
             xtensa-espressif_esp32s2_zephyr-elf)
               PLATFORM_ARGS+="-p esp32s2_saola "


### PR DESCRIPTION
Board was renamed upstream.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
