### PR TITLE
openocd: use hosted git2cl

### DIFF
--- a/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_git.bb
+++ b/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_git.bb
@@ -6,7 +6,7 @@ RDEPENDS_${PN} = "libusb1 hidapi"
 SRC_URI = " \
 	gitsm://github.com/zephyrproject-rtos/openocd.git;protocol=https;nobranch=1 \
 	"
-SRCREV = "51dbf7050b34a40f28c3fc7b5f4e49326c3e3aa6"
+SRCREV = "b89d626c64d8674e2a8b767915e0c6fd51ac8147"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Now use our own git2cl. The upstream repo very often is unreachable and
causes CI to fail.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
