### PR TITLE
xilinx_qemu: CI fixes

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/files/0001-Revert-target-arm-Enforce-alignment-for-LDM-STM.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/files/0001-Revert-target-arm-Enforce-alignment-for-LDM-STM.patch
@@ -1,0 +1,50 @@
+From 0d89d9811f25f757952ce098dcdf14c9465d2b65 Mon Sep 17 00:00:00 2001
+Message-ID: <0d89d9811f25f757952ce098dcdf14c9465d2b65.1747663373.git.michal.simek@amd.com>
+From: Michal Simek <michal.simek@amd.com>
+Date: Mon, 19 May 2025 15:17:52 +0200
+Subject: [PATCH] Revert "target/arm: Enforce alignment for LDM/STM"
+
+This reverts commit 9d7eb4183a17f129478adbdc314468d84573d83c.
+
+An alignment fault is generated if a data access is performed to an address
+that is not aligned for the size of the access, and strict alignment is
+required for the access.
+https://developer.arm.com/documentation/ddi0460/d/Memory-Protection-Unit/MPU-faults/Alignment-fault?lang=en
+
+The Qemu patch is likely correct and Zephyr test should be fixed but in the
+meantime revert this patch to pass tests in CI to give a time to find out
+what's wrong with Zephyr test.
+
+When this patch is revert issue is visible by this test:
+west twister -v -p qemu_cortex_r5 -O /tmp/twister -T tests/misc/llext-edk/
+
+Signed-off-by: Michal Simek <michal.simek@amd.com>
+---
+ target/arm/tcg/translate.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/target/arm/tcg/translate.c b/target/arm/tcg/translate.c
+index e555e885a13e..2b3ac25c71cd 100644
+--- a/target/arm/tcg/translate.c
++++ b/target/arm/tcg/translate.c
+@@ -7927,7 +7927,7 @@ static bool op_stm(DisasContext *s, arg_ldst_block *a)
+         } else {
+             tmp = load_reg(s, i);
+         }
+-        gen_aa32_st_i32(s, tmp, addr, mem_idx, MO_UL | MO_ALIGN);
++        gen_aa32_st32(s, tmp, addr, mem_idx);
+ 
+         /* No need to add after the last transfer.  */
+         if (++j != n) {
+@@ -8009,7 +8009,7 @@ static bool do_ldm(DisasContext *s, arg_ldst_block *a)
+         }
+ 
+         tmp = tcg_temp_new_i32();
+-        gen_aa32_ld_i32(s, tmp, addr, mem_idx, MO_UL | MO_ALIGN);
++        gen_aa32_ld32u(s, tmp, addr, mem_idx);
+         if (user) {
+             gen_helper_set_user_reg(tcg_env, tcg_constant_i32(i), tmp);
+         } else if (i == a->rn) {
+-- 
+2.43.0
+

--- a/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/files/0001-Revert-target-arm-Revert-back-to-YIELD-for-WFI.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/files/0001-Revert-target-arm-Revert-back-to-YIELD-for-WFI.patch
@@ -1,0 +1,40 @@
+From ab42d46c10d4e24cd19fb3339fc2738ba7b4a45e Mon Sep 17 00:00:00 2001
+Message-ID: <ab42d46c10d4e24cd19fb3339fc2738ba7b4a45e.1747662482.git.michal.simek@amd.com>
+From: Stephanos Ioannidis <root@stephanos.io>
+Date: Wed, 8 Jan 2020 17:47:05 +0900
+Subject: [PATCH] Revert "target/arm: Revert back to YIELD for WFI"
+
+This reverts commit 5f38ea92fb697b94ad43f01fe162f3ed6e6b0e16.
+
+The commit 5f38ea92fb697b94ad43f01fe162f3ed6e6b0e16 was probably
+introduced in order to improve emulation performance, as well as to
+address the stability issue when running co-simulations (refer to the
+commit 708639f72be2a9425992ae9dc4b9a098dc804c94).
+
+This, unfortunately, breaks the WFI instruction; i.e. CPU is not halted
+and keeps running regardless of whether an interrupt occurs, and this
+is a problem for the Zephyr CI tests that expect the WFI instruction to
+do its job (in particular, tests/kernel/context is broken because of
+this change).
+
+Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
+---
+ target/arm/tcg/op_helper.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/target/arm/tcg/op_helper.c b/target/arm/tcg/op_helper.c
+index 1e9ff35f0c30..67add5c6973c 100644
+--- a/target/arm/tcg/op_helper.c
++++ b/target/arm/tcg/op_helper.c
+@@ -353,7 +353,7 @@ void HELPER(wfi)(CPUARMState *env, uint32_t insn_len)
+     }
+ 
+     qemu_mutex_lock_iothread();
+-    if (use_icount || 1) {
++    if (use_icount) {
+         cs->exception_index = EXCP_YIELD;
+     } else {
+         cs->halted = 1;
+-- 
+2.43.0
+

--- a/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/files/0002-Enable-WFI-CPU-halting-in-icount-mode.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/files/0002-Enable-WFI-CPU-halting-in-icount-mode.patch
@@ -1,0 +1,39 @@
+From 393c4e5f40fb4592b3cf8247feee73538f541437 Mon Sep 17 00:00:00 2001
+Message-ID: <393c4e5f40fb4592b3cf8247feee73538f541437.1747662482.git.michal.simek@amd.com>
+From: Stephanos Ioannidis <root@stephanos.io>
+Date: Wed, 26 Feb 2020 12:30:55 +0900
+Subject: [PATCH] Enable WFI CPU halting in icount mode
+
+This commit enables CPU halting via the WFI instruction in the
+icount mode.
+
+The PetaLinux patch initially disabled WFI CPU halting, possibly for
+performance reasons.
+
+Signed-off-by: Stephanos Ioannidis <root@stephanos.io>
+---
+ target/arm/tcg/op_helper.c | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/target/arm/tcg/op_helper.c b/target/arm/tcg/op_helper.c
+index 67add5c6973c..f76c6eb5484e 100644
+--- a/target/arm/tcg/op_helper.c
++++ b/target/arm/tcg/op_helper.c
+@@ -353,12 +353,8 @@ void HELPER(wfi)(CPUARMState *env, uint32_t insn_len)
+     }
+ 
+     qemu_mutex_lock_iothread();
+-    if (use_icount) {
+-        cs->exception_index = EXCP_YIELD;
+-    } else {
+-        cs->halted = 1;
+-        cs->exception_index = EXCP_HLT;
+-    }
++    cs->halted = 1;
++    cs->exception_index = EXCP_HLT;
+ 
+     /* Drive STANDBYWFI only if cpu reset-pin is inactive */
+     if (cs->reset_pin == false) {
+-- 
+2.43.0
+

--- a/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/files/0003-riscvXX-softmmu-Enable-emaclite-driver-for-MB-V.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/files/0003-riscvXX-softmmu-Enable-emaclite-driver-for-MB-V.patch
@@ -1,0 +1,42 @@
+From 42593cded8643f4bd365a51c7d83fec601e49167 Mon Sep 17 00:00:00 2001
+Message-ID: <42593cded8643f4bd365a51c7d83fec601e49167.1747662482.git.michal.simek@amd.com>
+From: Michal Simek <michal.simek@amd.com>
+Date: Fri, 25 Apr 2025 09:24:48 +0200
+Subject: [PATCH] riscvXX-softmmu: Enable emaclite driver for MB-V
+
+Emaclite can be also wired with MB-V that's why enable it by default.
+
+Signed-off-by: Michal Simek <michal.simek@amd.com>
+Signed-off-by: Francisco Iglesias <francisco.iglesias@amd.com>
+---
+ configs/devices/riscv32-softmmu/default.mak | 1 +
+ configs/devices/riscv64-softmmu/default.mak | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/configs/devices/riscv32-softmmu/default.mak b/configs/devices/riscv32-softmmu/default.mak
+index c6c3dcd4431a..7845858ae87c 100644
+--- a/configs/devices/riscv32-softmmu/default.mak
++++ b/configs/devices/riscv32-softmmu/default.mak
+@@ -33,6 +33,7 @@ CONFIG_XILINX_IOMODULE_PIT=y
+ CONFIG_XILINX_IOMODULE_GPI=y
+ CONFIG_XILINX_IOMODULE_GPO=y
+ CONFIG_XILINX_IOMODULE_INTC=y
++CONFIG_XILINX_ETHLITE=y
+ 
+ CONFIG_XLNX_ZYNQMP=y
+ CONFIG_XLNX_VERSAL=y
+diff --git a/configs/devices/riscv64-softmmu/default.mak b/configs/devices/riscv64-softmmu/default.mak
+index 4886ca35dcb7..4f5528eeda9a 100644
+--- a/configs/devices/riscv64-softmmu/default.mak
++++ b/configs/devices/riscv64-softmmu/default.mak
+@@ -20,6 +20,7 @@ CONFIG_XILINX=y
+ CONFIG_SSI=y
+ CONFIG_I2C=y
+ CONFIG_XILINX_AXI=y
++CONFIG_XILINX_ETHLITE=y
+ CONFIG_XILINX_SPI=y
+ CONFIG_XILINX_SPIPS=y
+ CONFIG_PTIMER=y
+-- 
+2.43.0
+

--- a/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/files/0004-riscv-Wire-CPU-timers.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/files/0004-riscv-Wire-CPU-timers.patch
@@ -1,0 +1,66 @@
+From 2b117b43bb34d5da17d096504c518ab5eaa362f0 Mon Sep 17 00:00:00 2001
+Message-ID: <2b117b43bb34d5da17d096504c518ab5eaa362f0.1747662482.git.michal.simek@amd.com>
+From: Michal Simek <michal.simek@amd.com>
+Date: Fri, 25 Apr 2025 09:54:45 +0200
+Subject: [PATCH] riscv: Wire CPU timers
+
+Our HW is supporting them and FDT model is not wiring them.
+
+Signed-off-by: Michal Simek <michal.simek@amd.com>
+---
+ target/riscv/cpu.c | 25 +++++++++++++------------
+ 1 file changed, 13 insertions(+), 12 deletions(-)
+
+diff --git a/target/riscv/cpu.c b/target/riscv/cpu.c
+index 2685728f8a28..3bd69a961830 100644
+--- a/target/riscv/cpu.c
++++ b/target/riscv/cpu.c
+@@ -553,6 +553,18 @@ static void rv128_base_cpu_init(Object *obj)
+ #endif
+ }
+ #else
++#ifndef CONFIG_USER_ONLY
++static uint64_t mb_v_rdtime(void *opaque)
++{
++    CPURISCVState *env = &RISCV_CPU(opaque)->env;
++    uint32_t time, timeh;
++
++    csr_ops[CSR_MCYCLE].read(env, CSR_MCYCLE, &time);
++    csr_ops[CSR_MCYCLEH].read(env, CSR_MCYCLEH, &timeh);
++    return (uint64_t) timeh << 32 | time;
++}
++#endif
++
+ static void rv32_base_cpu_init(Object *obj)
+ {
+     CPURISCVState *env = &RISCV_CPU(obj)->env;
+@@ -562,6 +574,7 @@ static void rv32_base_cpu_init(Object *obj)
+     env->priv_ver = PRIV_VERSION_LATEST;
+ #ifndef CONFIG_USER_ONLY
+     set_satp_mode_max_supported(RISCV_CPU(obj), VM_1_10_SV32);
++    riscv_cpu_set_rdtime_fn(env, mb_v_rdtime, obj);
+ #endif
+ }
+ 
+@@ -634,18 +647,6 @@ static void rv32_imafcu_nommu_cpu_init(Object *obj)
+     cpu->cfg.pmp = true;
+ }
+ 
+-#ifndef CONFIG_USER_ONLY
+-static uint64_t mb_v_rdtime(void *opaque)
+-{
+-    CPURISCVState *env = &RISCV_CPU(opaque)->env;
+-    uint32_t time, timeh;
+-
+-    csr_ops[CSR_MCYCLE].read(env, CSR_MCYCLE, &time);
+-    csr_ops[CSR_MCYCLEH].read(env, CSR_MCYCLEH, &timeh);
+-    return (uint64_t) timeh << 32 | time;
+-}
+-#endif
+-
+ static void rv32_microblaze_v_cpu_init(Object *obj)
+ {
+ #ifndef CONFIG_USER_ONLY
+-- 
+2.43.0
+

--- a/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/files/cross.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/files/cross.patch
@@ -11,28 +11,26 @@ Upstream-Status: Inappropriate [may be rewritten in a way upstream may accept?]
 Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
 
 ---
- configure | 4 ----
- 1 file changed, 4 deletions(-)
+ configure | 2 --
+ 1 file changed, 2 deletions(-)
 
-Index: qemu-8.0.0/configure
-===================================================================
---- qemu-8.0.0.orig/configure
-+++ qemu-8.0.0/configure
-@@ -2590,7 +2590,6 @@ if test "$skip_meson" = no; then
+diff --git a/configure b/configure
+index c1e03801f14d..bd81dcb98df8 100755
+--- a/configure
++++ b/configure
+@@ -1795,7 +1795,6 @@ if test "$skip_meson" = no; then
    echo "widl = [$(meson_quote $widl)]" >> $cross
    echo "windres = [$(meson_quote $windres)]" >> $cross
    echo "windmc = [$(meson_quote $windmc)]" >> $cross
 -  if test "$cross_compile" = "yes"; then
-     cross_arg="--cross-file config-meson.cross"
      echo "[host_machine]" >> $cross
      echo "system = '$targetos'" >> $cross
-@@ -2608,9 +2607,6 @@ if test "$skip_meson" = no; then
-     else
-         echo "endian = 'little'" >> $cross
-     fi
--  else
--    cross_arg="--native-file config-meson.cross"
+     case "$cpu" in
+@@ -1820,7 +1819,6 @@ if test "$skip_meson" = no; then
+     mv $native config-meson.native
+     meson_option_add --native-file
+     meson_option_add config-meson.native
 -  fi
    mv $cross config-meson.cross
-
-   rm -rf meson-private meson-info meson-logs
+   meson_add_machine_file config-meson.cross
+   if test -f "$source_path/configs/meson/$targetos.txt"; then

--- a/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/files/fixedmeson.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/files/fixedmeson.patch
@@ -1,13 +1,22 @@
-Upstream-Status: Inappropriate [workaround, would need a real fix for upstream]
+From 72002fcd5673d0144d3fe756521348e9381061e1 Mon Sep 17 00:00:00 2001
+Message-ID: <72002fcd5673d0144d3fe756521348e9381061e1.1747667452.git.michal.simek@amd.com>
+From: Michal Simek <michal.simek@amd.com>
+Date: Mon, 19 May 2025 17:10:43 +0200
+Subject: [PATCH] Upstream-Status: Inappropriate [workaround, would need a real
+ fix for upstream]
 
-Index: qemu-8.1.0/configure
-===================================================================
---- qemu-8.1.0.orig/configure
-+++ qemu-8.1.0/configure
-@@ -1032,12 +1032,7 @@ then
-     exit 1
- fi
+---
+ configure | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
 
+diff --git a/configure b/configure
+index bd81dcb98df8..d462e56417f2 100755
+--- a/configure
++++ b/configure
+@@ -964,12 +964,7 @@ fi
+ $mkvenv ensuregroup --dir "${source_path}/python/wheels" \
+      ${source_path}/pythondeps.toml meson || exit 1
+ 
 -# At this point, we expect Meson to be installed and available.
 -# We expect mkvenv or pip to have created pyvenv/bin/meson for us.
 -# We ignore PATH completely here: we want to use the venv's Meson
@@ -15,5 +24,9 @@ Index: qemu-8.1.0/configure
 -
 -meson="$(cd pyvenv/bin; pwd)/meson"
 +meson=`which meson`
-
+ 
  # Conditionally ensure Sphinx is installed.
+ 
+-- 
+2.43.0
+

--- a/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/files/no-pip.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/files/no-pip.patch
@@ -1,4 +1,8 @@
-qemu: Ensure pip and the python venv aren't used for meson
+From 757ff30fe336a1304355eefa3fc93e0b8cc86986 Mon Sep 17 00:00:00 2001
+Message-ID: <757ff30fe336a1304355eefa3fc93e0b8cc86986.1747667700.git.michal.simek@amd.com>
+From: Richard Purdie <richard.purdie@linuxfoundation.org>
+Date: Mon, 19 May 2025 17:14:55 +0200
+Subject: [PATCH] qemu: Ensure pip and the python venv aren't used for meson
 
 Qemu wants to use a supported python version and a specific meson version
 to "help" users and uses pip and creates a venv to do this. This is a nightmare
@@ -21,25 +25,31 @@ as it stands is a workaround.
 
 Upstream-Status: Inappropriate [oe specific]
 Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
+---
+ configure | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
 
-Index: qemu-8.1.2/configure
-===================================================================
---- qemu-8.1.2.orig/configure
-+++ qemu-8.1.2/configure
-@@ -1009,7 +1009,7 @@ python="$(command -v "$python")"
+diff --git a/configure b/configure
+index d462e56417f2..3aa817827525 100755
+--- a/configure
++++ b/configure
+@@ -946,7 +946,7 @@ python="$(command -v "$python")"
  echo "python determined to be '$python'"
  echo "python version: $($python --version)"
-
+ 
 -python="$($python -B "${source_path}/python/scripts/mkvenv.py" create pyvenv)"
 +python=python3
  if test "$?" -ne 0 ; then
      error_exit "python venv creation failed"
  fi
-@@ -1017,6 +1017,7 @@ fi
+@@ -954,6 +954,7 @@ fi
  # Suppress writing compiled files
  python="$python -B"
  mkvenv="$python ${source_path}/python/scripts/mkvenv.py"
 +mkvenv=true
+ 
+ # Finish preparing the virtual environment using vendored .whl files
+ 
+-- 
+2.43.0
 
- mkvenv_flags=""
- if test "$download" = "enabled" ; then

--- a/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/qemu-xilinx_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/qemu-xilinx_git.bb
@@ -12,6 +12,8 @@ SRCREV_FORMAT = "qemu"
 SRC_URI += "gitsm://github.com/Xilinx/qemu.git;protocol=https;nobranch=1;name=qemu \
            file://cross.patch \
            file://0004-configure-Add-pkg-config-handling-for-libgcrypt.patch \
+           file://0001-Revert-target-arm-Revert-back-to-YIELD-for-WFI.patch \
+           file://0002-Enable-WFI-CPU-halting-in-icount-mode.patch \
            file://0008-tests-meson.build-use-relative-path-to-refer-to-file.patch \
            file://fixedmeson.patch \
            file://no-pip.patch \

--- a/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/qemu-xilinx_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/qemu-xilinx_git.bb
@@ -6,7 +6,7 @@ RDEPENDS:${PN}-common:class-target += "bash"
 LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
                     file://COPYING.LIB;endline=24;md5=8c5efda6cf1e1b03dcfd0e6c0d271c7f"
 
-SRCREV_qemu = "01482fa113dcbfa785feb7d513df50d15ec4c5df"
+SRCREV_qemu = "b05c9752662eb4b8120a57454a323445d78d1463"
 SRCREV_FORMAT = "qemu"
 
 SRC_URI += "gitsm://github.com/Xilinx/qemu.git;protocol=https;nobranch=1;name=qemu \

--- a/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/qemu-xilinx_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/qemu-xilinx_git.bb
@@ -50,7 +50,7 @@ EXTRA_OECONF = " \
   --disable-strip --disable-libvduse --disable-vhost-user --disable-vnc \
   --enable-gcrypt --enable-plugins --disable-capstone --skip-meson \
   --disable-docs  --disable-sdl --disable-debug-info  --disable-cap-ng \
-  --disable-capstone --skip-meson --disable-download --disable-libnfs \
+  --disable-capstone --disable-download --disable-libnfs \
   --disable-libusb --disable-libiscsi --disable-usb-redir --disable-linux-aio \
   --disable-guest-agent --disable-libssh --disable-seccomp --disable-tpm \
   --disable-numa --disable-glusterfs --disable-virtfs --disable-xen \

--- a/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/qemu-xilinx_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/qemu-xilinx_git.bb
@@ -16,6 +16,7 @@ SRC_URI += "gitsm://github.com/Xilinx/qemu.git;protocol=https;nobranch=1;name=qe
            file://0002-Enable-WFI-CPU-halting-in-icount-mode.patch \
            file://0003-riscvXX-softmmu-Enable-emaclite-driver-for-MB-V.patch \
            file://0004-riscv-Wire-CPU-timers.patch \
+           file://0001-Revert-target-arm-Enforce-alignment-for-LDM-STM.patch \
            file://0008-tests-meson.build-use-relative-path-to-refer-to-file.patch \
            file://fixedmeson.patch \
            file://no-pip.patch \

--- a/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/qemu-xilinx_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu_xilinx/qemu-xilinx_git.bb
@@ -14,6 +14,8 @@ SRC_URI += "gitsm://github.com/Xilinx/qemu.git;protocol=https;nobranch=1;name=qe
            file://0004-configure-Add-pkg-config-handling-for-libgcrypt.patch \
            file://0001-Revert-target-arm-Revert-back-to-YIELD-for-WFI.patch \
            file://0002-Enable-WFI-CPU-halting-in-icount-mode.patch \
+           file://0003-riscvXX-softmmu-Enable-emaclite-driver-for-MB-V.patch \
+           file://0004-riscv-Wire-CPU-timers.patch \
            file://0008-tests-meson.build-use-relative-path-to-refer-to-file.patch \
            file://fixedmeson.patch \
            file://no-pip.patch \


### PR DESCRIPTION
@nashif reported me 3 issues which are reported by CI. 
Two of them are related to patches which have been removed but they were the part of previous QEMU version. 
Both of them are visible by running
west twister -v -p qemu_cortex_r5 -O /tmp/twister -T tests/kernel/context/
https://github.com/zephyrproject-rtos/zephyr-testing/actions/runs/15058691212/job/42329628698
https://github.com/zephyrproject-rtos/zephyr-testing/actions/runs/15058691212/job/42329629012

The last one is reproducible by running
west twister -v -p qemu_cortex_r5 -O /tmp/twister -T tests/misc/llext-edk/
https://github.com/zephyrproject-rtos/zephyr-testing/actions/runs/15058691212/job/42329629235
And it is tricky because it is coming from upstream QEMU commit  which is likely correct but still would be better to revert this functionality which wasn't the part of QEMU v6.0.0 but it gets merged to v6.1 development tree.
The reason is to provide time to find out the reason why unaligned accesses are triggered by Qemu test.

In the meantime Xilinx also released new Qemu version based on 8.2.7 which was used for testing above issues that's why better to directly use this version instead of rely on older version.