### PR TITLE
ci: move 0.17.x series to point to zephyr main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
       zephyr-ref:
         description: 'Zephyr Ref (branch, tag, SHA, ...)'
         required: true
-        default: collab-sdk-dev
+        default: main
       host:
         description: 'Host'
         type: choice
@@ -92,7 +92,7 @@ env:
   BUG_URL: 'https://github.com/zephyrproject-rtos/sdk-ng/issues'
   BUNDLE_NAME: Zephyr SDK
   BUNDLE_PREFIX: zephyr-sdk
-  ZEPHYR_REF: collab-sdk-dev
+  ZEPHYR_REF: main
 
 jobs:
   # Setup


### PR DESCRIPTION
0.17.x is frozen and needs to be compatible with main. So stop using
collab branch.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
