### PR TITLE
llvm: Increase timeout for picolibc testing

### DIFF
--- a/scripts/llvm/test-support/run-picolibc-tests.py
+++ b/scripts/llvm/test-support/run-picolibc-tests.py
@@ -67,7 +67,7 @@ def run_tests(meson_command, source_dir, build_dir, variant):
     )
 
     returncode = subprocess.run(
-        [meson_command, "test"],
+        [meson_command, "test", "-t", "20"],
         cwd=build_dir,
     ).returncode
 


### PR DESCRIPTION
compiler-rt has very slow floating point emulation which causes the long-double test to timeout on riscv. Increase the timeout by a factor of 20 to avoid this issue.