### PR TITLE
cmake: bump version of SDK in Kconfig / use new variant syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1834,7 +1834,7 @@ jobs:
         fi
 
         # Set toolchain variant
-        export ZEPHYR_TOOLCHAIN_VARIANT=zephyr-${{ matrix.toolchain }}
+        export ZEPHYR_TOOLCHAIN_VARIANT=zephyr/${{ matrix.toolchain }}
 
         # Run tests with twister
         TWISTER="${ZEPHYR_ROOT}/scripts/twister"

--- a/cmake/Zephyr-sdkConfig.cmake
+++ b/cmake/Zephyr-sdkConfig.cmake
@@ -13,7 +13,7 @@ get_filename_component(ZEPHYR_SDK_INSTALL_DIR ${CMAKE_CURRENT_LIST_DIR}/.. ABSOL
 set(ZEPHYR_SDK_INSTALL_DIR ${ZEPHYR_SDK_INSTALL_DIR})
 
 if(NOT DEFINED ZEPHYR_TOOLCHAIN_VARIANT)
-  set(ZEPHYR_TOOLCHAIN_VARIANT zephyr-gnu)
+  set(ZEPHYR_TOOLCHAIN_VARIANT "zephyr/gnu")
 endif()
 
 # Those are CMake package parameters.

--- a/cmake/zephyr/Kconfig
+++ b/cmake/zephyr/Kconfig
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-config TOOLCHAIN_ZEPHYR_0_17
+config TOOLCHAIN_ZEPHYR_0_18
 	def_bool y
 
 config TOOLCHAIN_ZEPHYR_SUPPORTS_THREAD_LOCAL_STORAGE
@@ -13,8 +13,7 @@ config TOOLCHAIN_ZEPHYR_SUPPORTS_GNU_EXTENSIONS
 
 config PICOLIBC_SUPPORTED
 	def_bool y
-	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr-gnu" \
-		|| "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr-llvm"
+	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr"
 	help
 	  Zephyr SDK >=0.16 always supports Picolibc for C and C++ development.
 
@@ -25,5 +24,5 @@ config PICOLIBC_DEFAULT
 	  Zephyr SDK >=0.17.1 always uses Picolibc
 
 choice COMPILER_OPTIMIZATIONS
-	default SPEED_OPTIMIZATIONS if ("$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr" || "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr-gnu") && CPP_EXCEPTIONS
+	default SPEED_OPTIMIZATIONS if ("$(TOOLCHAIN_VARIANT_COMPILER)" = "gnu") && CPP_EXCEPTIONS
 endchoice

--- a/meta-zephyr-sdk/recipes-devtools/qemu/qemu-zephyr_10.0.2.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/qemu-zephyr_10.0.2.bb
@@ -63,7 +63,7 @@ SRC_URI = "https://download.qemu.org/${BPN}-${PV}.tar.xz \
 UPSTREAM_CHECK_URI = "https://www.qemu.org"
 UPSTREAM_CHECK_REGEX = "qemu-(?P<pver>\d+(\.\d+)+)\.tar"
 
-SRC_URI[sha256sum] = "22c075601fdcf8c7b2671a839ebdcef1d4f2973eb6735254fd2e1bd0f30b3896"
+SRC_URI[sha256sum] = "ef786f2398cb5184600f69aef4d5d691efd44576a3cff4126d38d4c6fec87759"
 CVE_STATUS[CVE-2007-0998] = "not-applicable-config: The VNC server can expose host files uder some circumstances. We don't enable it by default."
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1609015#c11


### PR DESCRIPTION
Use alternative variant handling keeping zephyr variant supported.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
