### PR TITLE
Riscv fixes

### DIFF
--- a/cmake/zephyr/Kconfig
+++ b/cmake/zephyr/Kconfig
@@ -23,6 +23,9 @@ config PICOLIBC_DEFAULT
 	help
 	  Zephyr SDK >=0.17.1 always uses Picolibc
 
+# libstdc++ is built without exception support in -Os mode
+# gcc 14.3 has bugs compiling with -Os on riscv
 choice COMPILER_OPTIMIZATIONS
 	default SPEED_OPTIMIZATIONS if ("$(TOOLCHAIN_VARIANT_COMPILER)" = "gnu") && CPP_EXCEPTIONS
+	default SPEED_OPTIMIZATIONS if ("$(TOOLCHAIN_VARIANT_COMPILER)" = "gnu") && RISCV
 endchoice


### PR DESCRIPTION
Use SPEED_OPTIMIZATIONS by default for riscv (avoids compiler bugs with -Os).
Use -mstrict-align by default (avoids emitting misaligned memory operations).