### PR TITLE
qemu: Adding patch to fix qemu rx

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0001-target-xtensa-add-translation-for-wsr.mpucfg.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0001-target-xtensa-add-translation-for-wsr.mpucfg.patch
@@ -1,7 +1,7 @@
-From 7524720962d103fbf7c324b43aa84f26b6cc8835 Mon Sep 17 00:00:00 2001
+From d015746c863284d68ae860409982cb7a320f6341 Mon Sep 17 00:00:00 2001
 From: Max Filippov <jcmvbkbc@gmail.com>
 Date: Thu, 14 Dec 2023 18:08:26 -0800
-Subject: [PATCH 01/16] target/xtensa: add translation for wsr.mpucfg
+Subject: [PATCH 01/19] target/xtensa: add translation for wsr.mpucfg
 
 Although MPUCFG is not writable, the opcode wsr.mpucfg is defined and it
 just does nothing. Define wsr.mpucfg as nop.

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0002-target-xtensa-import-sample_controller32-core.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0002-target-xtensa-import-sample_controller32-core.patch
@@ -1,7 +1,7 @@
-From a46011e8eadebc4d8021f6a8522fa0ed52e89428 Mon Sep 17 00:00:00 2001
+From c8529a4ff0d5a205003d84ed40e300173213973f Mon Sep 17 00:00:00 2001
 From: Max Filippov <jcmvbkbc@gmail.com>
 Date: Thu, 14 Dec 2023 16:47:09 -0800
-Subject: [PATCH 02/16] target/xtensa: import sample_controller32 core
+Subject: [PATCH 02/19] target/xtensa: import sample_controller32 core
 
 This is an LX core with MPU and exclusive access options.
 

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0003-tests-tcg-xtensa-tidy-test-linker-script.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0003-tests-tcg-xtensa-tidy-test-linker-script.patch
@@ -1,7 +1,7 @@
-From ad202784183a635c281749f67ed2411e879facb3 Mon Sep 17 00:00:00 2001
+From 939da062ee835cbdd52be49c687160565c3d0fd6 Mon Sep 17 00:00:00 2001
 From: Max Filippov <jcmvbkbc@gmail.com>
 Date: Thu, 14 Dec 2023 16:46:08 -0800
-Subject: [PATCH 03/16] tests/tcg/xtensa: tidy test linker script
+Subject: [PATCH 03/19] tests/tcg/xtensa: tidy test linker script
 
 Drop MEMORY clause and related size definitions and output section
 region specifications. Drop .rodata output section as the tests don't

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0004-tests-tcg-xtensa-fix-SR-test-for-configs-with-MPU.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0004-tests-tcg-xtensa-fix-SR-test-for-configs-with-MPU.patch
@@ -1,7 +1,7 @@
-From dd5194b56b7a6ca2faedccfd96137c0304abe394 Mon Sep 17 00:00:00 2001
+From b26560c924c15d138ce6fa96f8271c2803b27ca6 Mon Sep 17 00:00:00 2001
 From: Max Filippov <jcmvbkbc@gmail.com>
 Date: Thu, 14 Dec 2023 18:14:00 -0800
-Subject: [PATCH 04/16] tests/tcg/xtensa: fix SR test for configs with MPU
+Subject: [PATCH 04/19] tests/tcg/xtensa: fix SR test for configs with MPU
 
 - atomctl is available not only in the presence of s32c1i, but also with
   the exclusive access option

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0005-target-xtensa-fix-sample_controller32-build-for-QEMU.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0005-target-xtensa-fix-sample_controller32-build-for-QEMU.patch
@@ -1,7 +1,7 @@
-From f427b780bb1241b675d7a710d224d233031b709d Mon Sep 17 00:00:00 2001
+From aa41c2f05735e5591a226925b66efa16788e84f8 Mon Sep 17 00:00:00 2001
 From: Daniel Leung <daniel.leung@intel.com>
 Date: Tue, 14 May 2024 09:52:26 -0700
-Subject: [PATCH 05/16] target/xtensa: fix sample_controller32 build for QEMU 7
+Subject: [PATCH 05/19] target/xtensa: fix sample_controller32 build for QEMU 7
 
 The original patches for adding sample_controller32 are based on
 QEMU 9. The GDB stub header file is not in the same place between

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0006-Revert-target-xtensa-Make-use-of-segment-in-pptlb-he.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0006-Revert-target-xtensa-Make-use-of-segment-in-pptlb-he.patch
@@ -1,7 +1,7 @@
-From ab661500c3afa2ba48d8635089bc9985a149b5a0 Mon Sep 17 00:00:00 2001
+From 63f8bfdd97e3b86d85eee10ee68902c84e1dfe8d Mon Sep 17 00:00:00 2001
 From: Anas Nashif <anas.nashif@intel.com>
 Date: Fri, 16 May 2025 17:58:04 -0400
-Subject: [PATCH 06/16] Revert "target/xtensa: Make use of 'segment' in pptlb
+Subject: [PATCH 06/19] Revert "target/xtensa: Make use of 'segment' in pptlb
  helper less confusing"
 
 This reverts commit b42ba4ea4322357fcbfcb0e6e613d79ede84de64.

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0007-qemu-Add-addition-environment-space-to-boot-loader-q.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0007-qemu-Add-addition-environment-space-to-boot-loader-q.patch
@@ -1,7 +1,7 @@
-From 42a7273b1d4fd681a432d40bc4092c3487b3a556 Mon Sep 17 00:00:00 2001
+From 5d6dccdcdb757eb7577b1f0ee0403c9307276f2d Mon Sep 17 00:00:00 2001
 From: Jason Wessel <jason.wessel@windriver.com>
 Date: Fri, 28 Mar 2014 17:42:43 +0800
-Subject: [PATCH 07/16] qemu: Add addition environment space to boot loader
+Subject: [PATCH 07/19] qemu: Add addition environment space to boot loader
  qemu-system-mips
 
 Upstream-Status: Inappropriate - OE uses deep paths

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0008-apic-fixup-fallthrough-to-PIC.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0008-apic-fixup-fallthrough-to-PIC.patch
@@ -1,7 +1,7 @@
-From d98f52b978273b4ee394f7ee3c00fdf966a0c2ec Mon Sep 17 00:00:00 2001
+From 0a062a8df964073d0a5261dea7c62530fa3a89a8 Mon Sep 17 00:00:00 2001
 From: Mark Asselstine <mark.asselstine@windriver.com>
 Date: Tue, 26 Feb 2013 11:43:28 -0500
-Subject: [PATCH 08/16] apic: fixup fallthrough to PIC
+Subject: [PATCH 08/19] apic: fixup fallthrough to PIC
 
 Commit 0e21e12bb311c4c1095d0269dc2ef81196ccb60a [Don't route PIC
 interrupts through the local APIC if the local APIC config says so.]

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0009-qemu-Do-not-include-file-if-not-exists.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0009-qemu-Do-not-include-file-if-not-exists.patch
@@ -1,7 +1,7 @@
-From 19b994a2d608eabfa52e8f327ae6dc0ea3653181 Mon Sep 17 00:00:00 2001
+From 82fcf7fca2378036c4638a213d905f34e8a783a4 Mon Sep 17 00:00:00 2001
 From: Oleksiy Obitotskyy <oobitots@cisco.com>
 Date: Wed, 25 Mar 2020 21:21:35 +0200
-Subject: [PATCH 09/16] qemu: Do not include file if not exists
+Subject: [PATCH 09/19] qemu: Do not include file if not exists
 
 Script configure checks for if_alg.h and check failed but
 if_alg.h still included.

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0010-qemu-Add-some-user-space-mmap-tweaks-to-address-musl.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0010-qemu-Add-some-user-space-mmap-tweaks-to-address-musl.patch
@@ -1,7 +1,7 @@
-From 923be76163f1e7a178431ee65c4867cb8e1a2fef Mon Sep 17 00:00:00 2001
+From 31ca39ae7a780467eff7622f297b4a529944ee11 Mon Sep 17 00:00:00 2001
 From: Richard Purdie <richard.purdie@linuxfoundation.org>
 Date: Fri, 8 Jan 2021 17:27:06 +0000
-Subject: [PATCH 10/16] qemu: Add some user space mmap tweaks to address musl
+Subject: [PATCH 10/19] qemu: Add some user space mmap tweaks to address musl
  32 bit
 
 When using qemu-i386 to build qemux86 webkitgtk on musl, it sits in an

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0011-qemu-Determinism-fixes.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0011-qemu-Determinism-fixes.patch
@@ -1,7 +1,7 @@
-From a23965528591e86e12c4eccb56ce045067acedf7 Mon Sep 17 00:00:00 2001
+From 2c4b34cea3a7c218f3e5033fcc90288e99180104 Mon Sep 17 00:00:00 2001
 From: Richard Purdie <richard.purdie@linuxfoundation.org>
 Date: Mon, 1 Mar 2021 13:00:47 +0000
-Subject: [PATCH 11/16] qemu: Determinism fixes
+Subject: [PATCH 11/19] qemu: Determinism fixes
 
 When sources are included within debug information, a couple of areas of the
 qemu build are not reproducible due to either full buildpaths or timestamps.

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0012-tests-meson.build-use-relative-path-to-refer-to-file.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0012-tests-meson.build-use-relative-path-to-refer-to-file.patch
@@ -1,7 +1,7 @@
-From 7362a4c35fcfe52fc63d80456b51a33fc597cc85 Mon Sep 17 00:00:00 2001
+From 7f8d3a99926937eac75c94ea6e977b11ebfe248b Mon Sep 17 00:00:00 2001
 From: Changqing Li <changqing.li@windriver.com>
 Date: Thu, 14 Jan 2021 06:33:04 +0000
-Subject: [PATCH 12/16] tests/meson.build: use relative path to refer to files
+Subject: [PATCH 12/19] tests/meson.build: use relative path to refer to files
 
 Fix error like:
 Fatal error: can't create tests/ptimer-test.p/..._qemu-5.2.0_hw_core_ptimer.c.o: File name too long

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0013-Define-MAP_SYNC-and-MAP_SHARED_VALIDATE-on-needed-li.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0013-Define-MAP_SYNC-and-MAP_SHARED_VALIDATE-on-needed-li.patch
@@ -1,7 +1,7 @@
-From 386c52f870dfb140fda43932a833d50db5d42495 Mon Sep 17 00:00:00 2001
+From 2872615d392d0b071abc07d1a8d66913a83a87ab Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Mon, 21 Mar 2022 10:09:38 -0700
-Subject: [PATCH 13/16] Define MAP_SYNC and MAP_SHARED_VALIDATE on needed linux
+Subject: [PATCH 13/19] Define MAP_SYNC and MAP_SHARED_VALIDATE on needed linux
  systems
 
 linux only wires MAP_SYNC and MAP_SHARED_VALIDATE for architectures

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0014-configure-lookup-meson-exutable-from-PATH.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0014-configure-lookup-meson-exutable-from-PATH.patch
@@ -1,7 +1,7 @@
-From 320d68aae92aa53ec79e99fb2fae6dcb0598e225 Mon Sep 17 00:00:00 2001
+From e69ee0ff86f7dbe7ac2d165b9dab3457a069a998 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Martin=20Hundeb=C3=B8ll?= <martin@geanix.com>
 Date: Wed, 22 May 2024 14:02:55 +0200
-Subject: [PATCH 14/16] configure: lookup meson exutable from PATH
+Subject: [PATCH 14/19] configure: lookup meson exutable from PATH
 
 Upstream-Status: Inappropriate [workaround, would need a real fix for upstream]
 ---

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0015-qemu-Ensure-pip-and-the-python-venv-aren-t-used-for-.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0015-qemu-Ensure-pip-and-the-python-venv-aren-t-used-for-.patch
@@ -1,7 +1,7 @@
-From a80210622f4f4d99ac31ccf9d77389c0a27a1930 Mon Sep 17 00:00:00 2001
+From f8df33e0ebe7a170eb60d45524b9cb931a8bf23b Mon Sep 17 00:00:00 2001
 From: Richard Purdie <richard.purdie@linuxfoundation.org>
 Date: Wed, 22 May 2024 13:58:23 +0200
-Subject: [PATCH 15/16] qemu: Ensure pip and the python venv aren't used for
+Subject: [PATCH 15/19] qemu: Ensure pip and the python venv aren't used for
  meson
 
 Qemu wants to use a supported python version and a specific meson version

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0016-target-riscv-kvm-do-not-use-non-portable-strerrornam.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0016-target-riscv-kvm-do-not-use-non-portable-strerrornam.patch
@@ -1,7 +1,7 @@
-From 6e1c3ecc759caac8cc1a48e42780e80c09b4ca16 Mon Sep 17 00:00:00 2001
+From 6541c70d230c8d5344484f63fd6895d2c54002b1 Mon Sep 17 00:00:00 2001
 From: Natanael Copa <ncopa@alpinelinux.org>
 Date: Wed, 18 Sep 2024 16:19:37 -0700
-Subject: [PATCH 16/16] target/riscv/kvm: do not use non-portable
+Subject: [PATCH 16/19] target/riscv/kvm: do not use non-portable
  strerrorname_np()
 
 strerrorname_np is non-portable and breaks building with musl libc.
@@ -21,10 +21,10 @@ Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/target/riscv/kvm/kvm-cpu.c b/target/riscv/kvm/kvm-cpu.c
-index 0f4997a918..4559d0fac2 100644
+index 8001ca153e..79fb43f92e 100644
 --- a/target/riscv/kvm/kvm-cpu.c
 +++ b/target/riscv/kvm/kvm-cpu.c
-@@ -1885,8 +1885,7 @@ static bool kvm_cpu_realize(CPUState *cs, Error **errp)
+@@ -1968,8 +1968,7 @@ static bool kvm_cpu_realize(CPUState *cs, Error **errp)
      if (riscv_has_ext(&cpu->env, RVV)) {
          ret = prctl(PR_RISCV_V_SET_CONTROL, PR_RISCV_V_VSTATE_CTRL_ON);
          if (ret) {

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0017-hw-timer-renesas_cmt-Update-renesas_cmt-timer.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0017-hw-timer-renesas_cmt-Update-renesas_cmt-timer.patch
@@ -1,0 +1,197 @@
+From f505208ee16c3b2e0c095f65d333c09f3deb5705 Mon Sep 17 00:00:00 2001
+From: Duy Nguyen <duy.nguyen.xa@renesas.com>
+Date: Tue, 17 Jun 2025 16:03:24 +0700
+Subject: [PATCH 17/19] hw/timer/renesas_cmt: Update renesas_cmt timer
+
+Correct CMCNT read value calculation
+
+Signed-off-by: Duy Nguyen <duy.nguyen.xa@renesas.com>
+Signed-off-by: Phi Tran <phi.tran.jg@bp.renesas.com>
+---
+ hw/timer/renesas_cmt.c         | 97 +++++++++++++++-------------------
+ include/hw/timer/renesas_cmt.h |  1 +
+ 2 files changed, 45 insertions(+), 53 deletions(-)
+
+diff --git a/hw/timer/renesas_cmt.c b/hw/timer/renesas_cmt.c
+index 93e7f58cc2..53de3c2aff 100644
+--- a/hw/timer/renesas_cmt.c
++++ b/hw/timer/renesas_cmt.c
+@@ -51,56 +51,44 @@ REG16(CMCR, 0)
+ REG16(CMCNT, 2)
+ REG16(CMCOR, 4)
+ 
+-static void update_events(RCMTState *cmt, int ch)
+-{
+-    int64_t next_time;
++static uint16_t read_cmcnt(RCMTState *cmt, int ch) {
++    if (!(cmt->cmstr & (1 << ch))) {
++        return cmt->cmcnt[ch];
++    }
++    int64_t elapsed_ns = qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL) - cmt->tick[ch];
++    uint64_t ticks = (elapsed_ns * cmt->cmt_freq[ch]) / (NANOSECONDS_PER_SECOND);
++    uint32_t limit = cmt->cmcor[ch] + 1;
++    return (cmt->cmcnt[ch] + ticks) % limit;
++}
+ 
+-    if ((cmt->cmstr & (1 << ch)) == 0) {
+-        /* count disable, so not happened next event. */
++static void update_events(RCMTState *cmt, int ch) {
++    if (!(cmt->cmstr & (1 << ch))) {
+         return;
+     }
+-    next_time = cmt->cmcor[ch] - cmt->cmcnt[ch];
+-    next_time *= NANOSECONDS_PER_SECOND;
+-    next_time /= cmt->input_freq;
+-    /*
+-     * CKS -> div rate
+-     *  0 -> 8 (1 << 3)
+-     *  1 -> 32 (1 << 5)
+-     *  2 -> 128 (1 << 7)
+-     *  3 -> 512 (1 << 9)
+-     */
+-    next_time *= 1 << (3 + FIELD_EX16(cmt->cmcr[ch], CMCR, CKS) * 2);
+-    next_time += qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL);
+-    timer_mod(&cmt->timer[ch], next_time);
+-}
++    uint16_t current = read_cmcnt(cmt, ch);
++    uint32_t remain = (cmt->cmcor[ch] + 1) - current;
++    if (remain == 0) {
++        remain = cmt->cmcor[ch] + 1;
++    }
++    int64_t next_time = (int64_t)remain * NANOSECONDS_PER_SECOND / cmt->cmt_freq[ch];
+ 
+-static int64_t read_cmcnt(RCMTState *cmt, int ch)
+-{
+-    int64_t delta, now = qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL);
++    int64_t now = qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL);
++    int64_t fire_time = now + next_time;
+ 
+-    if (cmt->cmstr & (1 << ch)) {
+-        delta = (now - cmt->tick[ch]);
+-        delta /= NANOSECONDS_PER_SECOND;
+-        delta /= cmt->input_freq;
+-        delta /= 1 << (3 + FIELD_EX16(cmt->cmcr[ch], CMCR, CKS) * 2);
+-        cmt->tick[ch] = now;
+-        return cmt->cmcnt[ch] + delta;
+-    } else {
+-        return cmt->cmcnt[ch];
++    if (fire_time <= now) {
++        fire_time = now + 1;
+     }
++
++    timer_mod(&cmt->timer[ch], fire_time);
+ }
+ 
+ static uint64_t cmt_read(void *opaque, hwaddr offset, unsigned size)
+ {
+     RCMTState *cmt = opaque;
+     int ch = offset / 0x08;
+-    uint64_t ret;
+ 
+     if (offset == A_CMSTR) {
+-        ret = 0;
+-        ret = FIELD_DP16(ret, CMSTR, STR,
+-                         FIELD_EX16(cmt->cmstr, CMSTR, STR));
+-        return ret;
++        return FIELD_EX16(cmt->cmstr, CMSTR, STR);
+     } else {
+         offset &= 0x07;
+         if (ch == 0) {
+@@ -108,12 +96,7 @@ static uint64_t cmt_read(void *opaque, hwaddr offset, unsigned size)
+         }
+         switch (offset) {
+         case A_CMCR:
+-            ret = 0;
+-            ret = FIELD_DP16(ret, CMCR, CKS,
+-                             FIELD_EX16(cmt->cmstr, CMCR, CKS));
+-            ret = FIELD_DP16(ret, CMCR, CMIE,
+-                             FIELD_EX16(cmt->cmstr, CMCR, CMIE));
+-            return ret;
++            return cmt->cmcr[ch];
+         case A_CMCNT:
+             return read_cmcnt(cmt, ch);
+         case A_CMCOR:
+@@ -123,12 +106,13 @@ static uint64_t cmt_read(void *opaque, hwaddr offset, unsigned size)
+     qemu_log_mask(LOG_UNIMP, "renesas_cmt: Register 0x%" HWADDR_PRIX " "
+                              "not implemented\n",
+                   offset);
+-    return UINT64_MAX;
++    return UINT16_MAX;
+ }
+ 
+-static void start_stop(RCMTState *cmt, int ch, int st)
+-{
+-    if (st) {
++static void start_stop(RCMTState *cmt, int ch, int enable) {
++    if (enable) {
++        cmt->cmcnt[ch] = 0;
++        cmt->tick[ch] = qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL);
+         update_events(cmt, ch);
+     } else {
+         timer_del(&cmt->timer[ch]);
+@@ -155,9 +139,13 @@ static void cmt_write(void *opaque, hwaddr offset, uint64_t val, unsigned size)
+                                        FIELD_EX16(val, CMCR, CKS));
+             cmt->cmcr[ch] = FIELD_DP16(cmt->cmcr[ch], CMCR, CMIE,
+                                        FIELD_EX16(val, CMCR, CMIE));
++            cmt->cmt_freq[ch] =
++                cmt->input_freq / (8u << (2 * FIELD_EX16(cmt->cmcr[ch], CMCR, CKS)));
++            update_events(cmt, ch);
+             break;
+         case 2:
+             cmt->cmcnt[ch] = val;
++            cmt->tick[ch] = qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL);
+             break;
+         case 4:
+             cmt->cmcor[ch] = val;
+@@ -216,26 +204,29 @@ static void rcmt_reset(DeviceState *dev)
+ {
+     RCMTState *cmt = RCMT(dev);
+     cmt->cmstr = 0;
+-    cmt->cmcr[0] = cmt->cmcr[1] = 0;
+-    cmt->cmcnt[0] = cmt->cmcnt[1] = 0;
+-    cmt->cmcor[0] = cmt->cmcor[1] = 0xffff;
++    for (int i = 0; i < CMT_CH; i++) {
++        cmt->cmcr[i] = 0;
++        cmt->cmcnt[i] = 0;
++        cmt->cmcor[i] = 0xFFFF;
++        cmt->tick[i] = 0;
++    }
+ }
+ 
+ static void rcmt_init(Object *obj)
+ {
+     SysBusDevice *d = SYS_BUS_DEVICE(obj);
+     RCMTState *cmt = RCMT(obj);
+-    int i;
+ 
+     memory_region_init_io(&cmt->memory, OBJECT(cmt), &cmt_ops,
+                           cmt, "renesas-cmt", 0x10);
+     sysbus_init_mmio(d, &cmt->memory);
+ 
+-    for (i = 0; i < ARRAY_SIZE(cmt->cmi); i++) {
++    for (int i = 0; i < CMT_CH; i++) {
+         sysbus_init_irq(d, &cmt->cmi[i]);
++        cmt->cmt_freq[i] = cmt->input_freq >> 3;
++        timer_init_ns(&cmt->timer[i], QEMU_CLOCK_VIRTUAL,
++                      (i == 0 ? timer_event0 : timer_event1), cmt);
+     }
+-    timer_init_ns(&cmt->timer[0], QEMU_CLOCK_VIRTUAL, timer_event0, cmt);
+-    timer_init_ns(&cmt->timer[1], QEMU_CLOCK_VIRTUAL, timer_event1, cmt);
+ }
+ 
+ static const VMStateDescription vmstate_rcmt = {
+diff --git a/include/hw/timer/renesas_cmt.h b/include/hw/timer/renesas_cmt.h
+index 1c0b65c1d5..3d7a3c624f 100644
+--- a/include/hw/timer/renesas_cmt.h
++++ b/include/hw/timer/renesas_cmt.h
+@@ -29,6 +29,7 @@ struct RCMTState {
+     /*< public >*/
+ 
+     uint64_t input_freq;
++    uint64_t cmt_freq[CMT_CH];
+     MemoryRegion memory;
+ 
+     uint16_t cmstr;
+-- 
+2.43.0
+

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0018-target-rx-Update-flow-of-interrupt-execution-for-tar.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0018-target-rx-Update-flow-of-interrupt-execution-for-tar.patch
@@ -1,0 +1,49 @@
+From 7aebbd5ae1c11fd6a8c5d567f9cac1f315516a1e Mon Sep 17 00:00:00 2001
+From: Duy Nguyen <duy.nguyen.xa@renesas.com>
+Date: Tue, 17 Jun 2025 16:40:22 +0700
+Subject: [PATCH 18/19] target/rx: Update flow of interrupt execution for
+ target rx
+
+do_interrupt function is call directly from CPU exception so we
+need to add condition to check for CPU exception in case of
+hardware interrupt is preempted to prevent unexpect behavior
+
+Signed-off-by: Duy Nguyen <duy.nguyen.xa@renesas.com>
+---
+ target/rx/helper.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/target/rx/helper.c b/target/rx/helper.c
+index e8aabf40ff..60958ad032 100644
+--- a/target/rx/helper.c
++++ b/target/rx/helper.c
+@@ -48,7 +48,6 @@ void rx_cpu_do_interrupt(CPUState *cs)
+     uint32_t save_psw;
+ 
+     env->in_sleep = 0;
+-
+     if (env->psw_u) {
+         env->usp = env->regs[0];
+     } else {
+@@ -56,8 +55,9 @@ void rx_cpu_do_interrupt(CPUState *cs)
+     }
+     save_psw = rx_cpu_pack_psw(env);
+     env->psw_pm = env->psw_i = env->psw_u = 0;
++    int32_t vec = cs->exception_index;
+ 
+-    if (do_irq) {
++    if (do_irq && vec < 0) {
+         if (do_irq & CPU_INTERRUPT_FIR) {
+             env->bpc = env->pc;
+             env->bpsw = save_psw;
+@@ -79,7 +79,6 @@ void rx_cpu_do_interrupt(CPUState *cs)
+                           "interrupt 0x%02x raised\n", env->ack_irq);
+         }
+     } else {
+-        uint32_t vec = cs->exception_index;
+         const char *expname = "unknown exception";
+ 
+         env->isp -= 4;
+-- 
+2.43.0
+

--- a/meta-zephyr-sdk/recipes-devtools/qemu/files/0019-target-rx-Reset-the-CPU-at-qemu-reset-time.patch
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/files/0019-target-rx-Reset-the-CPU-at-qemu-reset-time.patch
@@ -1,0 +1,51 @@
+From 910fc70626e1edaea2954e40fabb5a1ae4a1dcc6 Mon Sep 17 00:00:00 2001
+From: Duy Nguyen <duy.nguyen.xa@renesas.com>
+Date: Fri, 20 Jun 2025 17:36:26 +0700
+Subject: [PATCH 19/19] target/rx: Reset the CPU at qemu reset time
+
+This ensure that the CPU gets reset every time QEMU resets.
+
+Signed-off-by: Keith Packard <keithp@keithp.com>
+Signed-off-by: Duy Nguyen <duy.nguyen.xa@renesas.com>
+---
+ target/rx/cpu.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/target/rx/cpu.c b/target/rx/cpu.c
+index 0ba0d55ab5..5a412746db 100644
+--- a/target/rx/cpu.c
++++ b/target/rx/cpu.c
+@@ -27,6 +27,7 @@
+ #include "hw/loader.h"
+ #include "fpu/softfloat.h"
+ #include "tcg/debug-assert.h"
++#include "system/reset.h"
+ 
+ static void rx_cpu_set_pc(CPUState *cs, vaddr value)
+ {
+@@ -129,6 +130,13 @@ static ObjectClass *rx_cpu_class_by_name(const char *cpu_model)
+     return oc;
+ }
+ 
++static void rx_cpu_reset(void *opaque)
++{
++    RXCPU *cpu = opaque;
++
++    cpu_reset(CPU(cpu));
++}
++
+ static void rx_cpu_realize(DeviceState *dev, Error **errp)
+ {
+     CPUState *cs = CPU(dev);
+@@ -142,7 +150,7 @@ static void rx_cpu_realize(DeviceState *dev, Error **errp)
+     }
+ 
+     qemu_init_vcpu(cs);
+-    cpu_reset(cs);
++    qemu_register_reset(rx_cpu_reset, RX_CPU(cs));
+ 
+     rcc->parent_realize(dev, errp);
+ }
+-- 
+2.43.0
+

--- a/meta-zephyr-sdk/recipes-devtools/qemu/qemu-zephyr_10.0.2.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/qemu-zephyr_10.0.2.bb
@@ -56,6 +56,8 @@ SRC_URI = "https://download.qemu.org/${BPN}-${PV}.tar.xz \
 	   file://0014-configure-lookup-meson-exutable-from-PATH.patch            \
 	   file://0015-qemu-Ensure-pip-and-the-python-venv-aren-t-used-for-.patch \
 	   file://0016-target-riscv-kvm-do-not-use-non-portable-strerrornam.patch \
+       file://0017-hw-timer-renesas_cmt-Update-renesas_cmt-timer.patch \
+       file://0018-target-rx-Update-flow-of-interrupt-execution-for-tar.patch \
            file://qemu-guest-agent.init \
            file://qemu-guest-agent.udev \
            "


### PR DESCRIPTION
This commit adding 2 patch to fix for qemu_rx
- 1st patch is to fix for timer accurarcy issue
- 2nd patch is to fix for flow of execute interrupt handling function for normal interrup and CPU exception
- 3rd patch is to add Reset the CPU at qemu reset time so elf target can be execute when use device loader