### PR TITLE
ci: when testing, install python 3.12, required by zephyr now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1456,9 +1456,9 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        # Force Python 3.10, which is the minimum Python version supported by
+        # Force Python 3.12, which is the minimum Python version supported by
         # Zephyr and intended to be used with Zephyr SDK.
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Set up test environment (Linux)
       if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
Zephyr now requires python 3.12, so install this version when testing
the SDK.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
