### PR TITLE
meta-zephyr-sdk: qemu: Pull in RX arch fixes

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/qemu/qemu-zephyr_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu/qemu-zephyr_git.bb
@@ -37,7 +37,7 @@ inherit pkgconfig systemd python3native
 LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
                     file://COPYING.LIB;endline=24;md5=8c5efda6cf1e1b03dcfd0e6c0d271c7f"
 
-SRCREV = "37b8667bf62f568167b0ef28aa7e6a0878218ae7"
+SRCREV = "fe132ed0c9ae14a56bbf94b1d0d16b029b671c62"
 SRC_URI = "gitsm://github.com/zephyrproject-rtos/qemu.git;protocol=https;nobranch=1 \
            file://powerpc_rom.bin \
            file://run-ptest \


### PR DESCRIPTION
This commit pulls in various RX architecture fixes for QEMU from zephyrproject-rtos/sdk-ng#944.

From the original PR:

> * 1st patch is to fix for timer accurarcy issue
> * 2nd patch is to fix for flow of execute interrupt handling function for
    normal interrup and CPU exception
> * 3rd patch is to add Reset the CPU at qemu reset time so elf target can
    be execute when use device loader

---

QEMU PR: https://github.com/zephyrproject-rtos/qemu/pull/11