### PR TITLE
gdb: Default to _WIN32_WINNT=0x0600

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,11 +500,8 @@ jobs:
         # Install dependencies for cross compilation
         if [ "${{ matrix.host.name }}" == "windows-x86_64" ]; then
           # Make MinGW-w64 win32 cross toolchain available in PATH
-          #echo "/opt/mingw-w64-win32/bin" >> $GITHUB_PATH
-          #export PATH="/opt/mingw-w64-win32/bin:$PATH"
-          # Install MinGW-w64 cross toolchain
-          sudo apt-get install -y binutils-mingw-w64 gcc-mingw-w64 \
-                                  g++-mingw-w64
+          echo "/opt/mingw-w64-win32/bin" >> $GITHUB_PATH
+          export PATH="/opt/mingw-w64-win32/bin:$PATH"
 
           # Build and install libboost-regex for MinGW-w64 host
           ## Check out Boost library source code


### PR DESCRIPTION
This commit pulls in the GDB patch that sets `_WIN32_WINNT` to 0x0600
when not explicitly defined in the CFLAGS.

Note that, libstdc++, when building with the win32 thread model, only
supports std::mutex and std:condition_variable if _WIN32_WINNT >=
0x0600.

---

GDB PR: https://github.com/zephyrproject-rtos/binutils-gdb/pull/18

Tested in https://github.com/zephyrproject-rtos/sdk-ng/actions/runs/16438257464

Fixes https://github.com/zephyrproject-rtos/sdk-ng/issues/964