### PR TITLE
[v0.17-branch] ci: Use sdk-build v1.3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
           MATRIX_HOSTS+='{
               "name": "linux-x86_64",
               "runner": "zephyr-runner-v2-linux-x64-4xlarge",
-              "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.3.2",
+              "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.3.9",
               "archive": "tar.xz"
             },'
         fi
@@ -268,7 +268,7 @@ jobs:
           MATRIX_HOSTS+='{
               "name": "linux-aarch64",
               "runner": "zephyr-runner-v2-linux-arm64-4xlarge",
-              "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.3.2",
+              "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.3.9",
               "archive": "tar.xz"
             },'
         fi
@@ -295,7 +295,7 @@ jobs:
           MATRIX_HOSTS+='{
               "name": "windows-x86_64",
               "runner": "zephyr-runner-v2-linux-x64-4xlarge",
-              "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.3.2",
+              "container": "ghcr.io/zephyrproject-rtos/sdk-build:v1.3.9",
               "archive": "7z"
             },'
         fi


### PR DESCRIPTION
This commit updates the CI workflow to use the SDK build image v1.3.9, which updates the Debian Buster APT repository URL to `archive.debian.org` because `deb.debian.org` no longer hosts the Debian Buster packages.

Note that the MinGW-related additions in the sdk-build v1.3.9 image does not affect the SDK 0.17 build because the CI workflow does not actively attempt to use them.