### PR TITLE
ci: Fix Linux and macOS test names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,7 +351,7 @@ jobs:
 
         if [ "${build_host_linux_x86_64}" == "y" ]; then
           MATRIX_TESTENVS+='{
-              "name": "ubuntu-20.04-x86_64",
+              "name": "ubuntu-24.04-x86_64",
               "runner": "zephyr-runner-v2-linux-x64-4xlarge",
               "container": "ghcr.io/zephyrproject-rtos/ci:main",
               "bundle-host": "linux-x86_64",
@@ -361,7 +361,7 @@ jobs:
 
         if [ "${build_host_linux_aarch64}" == "y" ]; then
           MATRIX_TESTENVS+='{
-              "name": "ubuntu-20.04-aarch64",
+              "name": "ubuntu-24.04-aarch64",
               "runner": "zephyr-runner-v2-linux-arm64-4xlarge",
               "container": "ghcr.io/zephyrproject-rtos/ci:main",
               "bundle-host": "linux-aarch64",
@@ -371,7 +371,7 @@ jobs:
 
         if [ "${build_host_macos_x86_64}" == "y" ]; then
           MATRIX_TESTENVS+='{
-              "name": "macos-11-x86_64",
+              "name": "macos-15-x86_64",
               "runner": "zephyr-runner-v2-macos-arm64-2xlarge",
               "container": "",
               "bundle-host": "macos-x86_64",
@@ -381,7 +381,7 @@ jobs:
 
         if [ "${build_host_macos_aarch64}" == "y" ]; then
           MATRIX_TESTENVS+='{
-              "name": "macos-11-aarch64",
+              "name": "macos-15-aarch64",
               "runner": "zephyr-runner-v2-macos-arm64-2xlarge",
               "container": "",
               "bundle-host": "macos-aarch64",


### PR DESCRIPTION
The Linux CI Docker image is now based on Ubuntu 24.04, and the macOS zephyr-runner runs with macOS 15.3-based image.