### PR TITLE
ci: Fix Linux test name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,7 @@ jobs:
 
         if [ "${build_host_linux_x86_64}" == "y" ]; then
           MATRIX_TESTENVS+='{
-              "name": "ubuntu-20.04-x86_64",
+              "name": "ubuntu-24.04-x86_64",
               "runner": "zephyr-runner-v2-linux-x64-4xlarge",
               "container": "ghcr.io/zephyrproject-rtos/ci:master",
               "bundle-host": "linux-x86_64",
@@ -353,7 +353,7 @@ jobs:
 
         if [ "${build_host_linux_aarch64}" == "y" ]; then
           MATRIX_TESTENVS+='{
-              "name": "ubuntu-20.04-aarch64",
+              "name": "ubuntu-24.04-aarch64",
               "runner": "zephyr-runner-v2-linux-arm64-4xlarge",
               "container": "ghcr.io/zephyrproject-rtos/ci:master",
               "bundle-host": "linux-aarch64",


### PR DESCRIPTION
The Linux CI DOcker image is now based on Ubuntu 24.04.