### PR TITLE
[v0.17-branch] ci: Run tests against Zephyr v4.2-branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ env:
   BUG_URL: 'https://github.com/zephyrproject-rtos/sdk-ng/issues'
   BUNDLE_NAME: Zephyr SDK
   BUNDLE_PREFIX: zephyr-sdk
-  ZEPHYR_REF: main
+  ZEPHYR_REF: v4.2-branch
 
 jobs:
   # Setup


### PR DESCRIPTION
SDK 0.17 needs to be tested with Zephyr v4.2.