### PR TITLE
cmake: Parse ZEPHYR_TOOLCHAIN_VARIANT in SDK instead of Zephyr

### DIFF
--- a/cmake/Zephyr-sdkConfig.cmake
+++ b/cmake/Zephyr-sdkConfig.cmake
@@ -12,9 +12,25 @@ set(SDK_MAJOR_MINOR_MICRO ${SDK_VERSION})
 get_filename_component(ZEPHYR_SDK_INSTALL_DIR ${CMAKE_CURRENT_LIST_DIR}/.. ABSOLUTE)
 set(ZEPHYR_SDK_INSTALL_DIR ${ZEPHYR_SDK_INSTALL_DIR})
 
-if(NOT DEFINED ZEPHYR_TOOLCHAIN_VARIANT)
-  set(ZEPHYR_TOOLCHAIN_VARIANT "zephyr/gnu")
+# Check and see if the user specified a toolchain
+if(DEFINED ZEPHYR_TOOLCHAIN_VARIANT)
+  # Check and see if the specified toolchain includes a compiler
+  if(ZEPHYR_TOOLCHAIN_VARIANT MATCHES "^([^/])+/([^/]+)$")
+    # Replace any existing values with the provided components
+    set(ZEPHYR_TOOLCHAIN_VARIANT "${CMAKE_MATCH_1}" CACHE STRING "toolchain" FORCE)
+    set(TOOLCHAIN_VARIANT_COMPILER "${CMAKE_MATCH_2}" CACHE STRING "compiler" FORCE)
+  endif()
+else()
+  set(ZEPHYR_TOOLCHAIN_VARIANT "zephyr")
 endif()
+
+# When using the Zephyr SDK, use the gnu compiler by default
+if(ZEPHYR_TOOLCHAIN_VARIANT STREQUAL "zephyr" AND NOT DEFINED TOOLCHAIN_VARIANT_COMPILER)
+  set(TOOLCHAIN_VARIANT_COMPILER "gnu")
+endif()
+
+set(ENV{ZEPHYR_TOOLCHAIN_VARIANT} "${ZEPHYR_TOOLCHAIN_VARIANT}")
+set(ENV{TOOLCHAIN_VARIANT_COMPILER} "${TOOLCHAIN_VARIANT_COMPILER}")
 
 # Those are CMake package parameters.
 set(Zephyr-sdk_FOUND True)


### PR DESCRIPTION
When ZEPHYR_TOOLCHAIN_VARIANT is of the form toolchain/compiler, it needs to be split into the toolchain (which overwrites ZEPHYR_TOOLCHAIN_VARIANT) and compiler (stored in
TOOLCHAIN_VARIANT_COMPILER).

Otherwise, when defined, it is left alone. When undefined it is set to "zephyr".

Finally, if the value is "zephyr" and no TOOLCHAIN_VARIANT_COMPILER setting is present, then TOOLCHAIN_VARIANT_COMPILER is set to "gnu".

This allows existing configurations which set ZEPHYR_TOOLCHAIN_VARIANT to "zephyr" to work with the new SDK and allows Zephyr to easily support both old and new variable settings during the SDK transition period.