### PR TITLE
cmake: Allow -Os on RISC-V again

### DIFF
--- a/cmake/zephyr/Kconfig
+++ b/cmake/zephyr/Kconfig
@@ -27,5 +27,4 @@ config PICOLIBC_DEFAULT
 # gcc 14.3 has bugs compiling with -Os on riscv
 choice COMPILER_OPTIMIZATIONS
 	default SPEED_OPTIMIZATIONS if ("$(TOOLCHAIN_VARIANT_COMPILER)" = "gnu") && CPP_EXCEPTIONS
-	default SPEED_OPTIMIZATIONS if ("$(TOOLCHAIN_VARIANT_COMPILER)" = "gnu") && RISCV
 endchoice


### PR DESCRIPTION
The previously detected regressions when building with -Os on RISC-V have been resolved.