### PR TITLE
hosttools: add stm32flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following host tools are available as part of the Zephyr SDK:
 - OpenOCD
 - QEMU
 - Xilinx QEMU
+- stm32flash
 
 ## Releases
 

--- a/meta-zephyr-sdk/recipes-hosttools/stm32flash/stm32flash_git.bb
+++ b/meta-zephyr-sdk/recipes-hosttools/stm32flash/stm32flash_git.bb
@@ -1,0 +1,13 @@
+SUMMARY = "Open source flash program using STM32 ARM microcontrollers using the built-in ST serial bootloader"
+HOMEPAGE = "https://sourceforge.net/projects/stm32flash/"
+LICENSE = "GPL-2.0+"
+LIC_FILES_CHKSUM = "file://gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+SRC_URI = "${SOURCEFORGE_MIRROR}/${BPN}/${BP}.tar.gz"
+SRCREV = "b89d626c64d8674e2a8b767915e0c6fd51ac8147"
+
+S = "${WORKDIR}/${BPN}"
+
+do_install() {
+	oe_runmake install DESTDIR=${D} PREFIX=${prefix}
+}


### PR DESCRIPTION
Add stm32flash utility to hosttools.
It's a small open source tool to flash STM32 MCUs using the serial bootloader.