### PR TITLE
ci: twister: Fix "SDK Build Job ID" terminology

### DIFF
--- a/.github/workflows/twister.yml
+++ b/.github/workflows/twister.yml
@@ -3,8 +3,8 @@ name: Twister
 on:
   workflow_dispatch:
     inputs:
-      sdk-build-job-id:
-        description: 'SDK Build Job ID'
+      sdk-build-run-id:
+        description: 'SDK Build Run ID'
         required: true
       sdk-bundle-basename:
         description: 'SDK Bundle Base Name'
@@ -268,12 +268,12 @@ jobs:
       # with:
       #   name: ${{ env.BUNDLE_NAME }}
       #   path: artifacts
-      #   run-id: ${{ github.event.inputs.sdk-build-job-id }}
+      #   run-id: ${{ github.event.inputs.sdk-build-run-id }}
       #   github-token: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh run download \
           -R ${GITHUB_REPOSITORY} \
-          ${{ github.event.inputs.sdk-build-job-id }} \
+          ${{ github.event.inputs.sdk-build-run-id }} \
           -n ${BUNDLE_NAME} \
           -D artifacts
       env:


### PR DESCRIPTION
The Twister workflow input "SDK Build Job ID" is misleading because it actually refers to the workflow run ID (i.e. numeric ID referring to a specific run) instead of the job ID, which is a string identifying a unique job in a workflow.