### PR TITLE
qemu-arc: Fix arc64 emulation bugs for double load/store operations

### DIFF
--- a/meta-zephyr-sdk/recipes-devtools/qemu_arc/qemu-arc_git.bb
+++ b/meta-zephyr-sdk/recipes-devtools/qemu_arc/qemu-arc_git.bb
@@ -5,7 +5,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
                     file://COPYING.LIB;endline=24;md5=8c5efda6cf1e1b03dcfd0e6c0d271c7f"
 
-SRCREV = "b46c4ec2d07a4c56c426b3d48195d6f2902226e5"
+SRCREV = "76e0fa9053b4184a29c9077959d484047eefe521"
 SRC_URI = "gitsm://github.com/foss-for-synopsys-dwc-arc-processors/qemu.git;protocol=https;nobranch=1 \
 	   file://cross.patch \
 "


### PR DESCRIPTION
Move to current synopsys master version:

	Implement {push,pop}dl_s.
	Rewrite translation functions for memory operations
	Add FPUv2 instructions.