### PR TITLE
ci: Replace curl with wget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1462,8 +1462,8 @@ jobs:
       run: |
         # Add GitHub CLI source
         sudo mkdir -p -m 755 /etc/apt/keyrings
-        sudo curl -L -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-                  https://cli.github.com/packages/githubcli-archive-keyring.gpg
+        sudo wget -O /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+             https://cli.github.com/packages/githubcli-archive-keyring.gpg
         sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
         sudo mkdir -p -m 755 /etc/apt/sources.list.d
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null


### PR DESCRIPTION
Replace curl usage with wget since curl is not available in the Zephyr CI Docker image.