### PR TITLE
cmake: llvm: Use '=' for --config to improve compatibility

### DIFF
--- a/cmake/zephyr/llvm/target.cmake
+++ b/cmake/zephyr/llvm/target.cmake
@@ -37,7 +37,5 @@ if(DEFINED triple)
   unset(triple)
 endif()
 
-list(APPEND TOOLCHAIN_C_FLAGS --config
-	${ZEPHYR_SDK_INSTALL_DIR}/cmake/zephyr/llvm/clang_compiler_rt.cfg)
-list(APPEND TOOLCHAIN_LD_FLAGS --config
-	${ZEPHYR_SDK_INSTALL_DIR}/cmake/zephyr/llvm/clang_compiler_rt.cfg)
+list(APPEND TOOLCHAIN_C_FLAGS --config=${ZEPHYR_SDK_INSTALL_DIR}/cmake/zephyr/llvm/clang_compiler_rt.cfg)
+list(APPEND TOOLCHAIN_LD_FLAGS --config=${ZEPHYR_SDK_INSTALL_DIR}/cmake/zephyr/llvm/clang_compiler_rt.cfg)


### PR DESCRIPTION
This PR replaces the space with an equal sign when assigning the clang configuration file to the --config parameter.

This change improves compatibility with tools, such as CodeChecker, that parse the compilation database and expect compiler arguments to be separated by space.

This PR is essentially a port of https://github.com/zephyrproject-rtos/zephyr/pull/91841.