### PR TITLE
openocd: Pull in Bouffalo Lab chips support

### DIFF
--- a/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_git.bb
+++ b/meta-zephyr-sdk/recipes-hosttools/openocd/openocd_git.bb
@@ -6,7 +6,7 @@ RDEPENDS_${PN} = "libusb1 hidapi"
 SRC_URI = " \
 	gitsm://github.com/zephyrproject-rtos/openocd.git;protocol=https;nobranch=1 \
 	"
-SRCREV = "40c37a3748e5cfff3018eed45c8de6cc13c9c712"
+SRCREV = "662bf274f881afa0aec2c21040eedb91146d8c4a"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This commit pulls in commits related to adding support for Bouffalo Lab chips in OpenOCD from upstream. Those commits does not contain support for flashing the firmware.

DNM until https://github.com/zephyrproject-rtos/openocd/pull/72 is merged.