### PR TITLE
Enable Objective-C language support in config

### DIFF
--- a/configs/common.config
+++ b/configs/common.config
@@ -17,6 +17,7 @@ CT_GCC_SRC_CUSTOM=y
 CT_GCC_CUSTOM_LOCATION="${GITHUB_WORKSPACE}/gcc"
 CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array"
 CT_CC_LANG_CXX=y
+CT_CC_LANG_OBJC=y
 
 # Newlib
 CT_NEWLIB_SRC_CUSTOM=y


### PR DESCRIPTION
Adding support for Objective-C in Zephyr. I am testing some local options (with a generic arm-none-eabi) that work well with a custom Objective-C runtime based on embedded systems. I would like to explore that with the proper Zephyr SDK supporting it.  