### PR TITLE
Use Zephyr 'main' branch for ci testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
       zephyr-ref:
         description: 'Zephyr Ref (branch, tag, SHA, ...)'
         required: true
-        default: collab-sdk-dev
+        default: main
       host:
         description: 'Host'
         type: choice
@@ -97,7 +97,7 @@ env:
   BUG_URL: 'https://github.com/zephyrproject-rtos/sdk-ng/issues'
   BUNDLE_NAME: Zephyr SDK
   BUNDLE_PREFIX: zephyr-sdk
-  ZEPHYR_REF: collab-sdk-dev
+  ZEPHYR_REF: main
 
 jobs:
   # Setup
@@ -1715,7 +1715,7 @@ jobs:
           popd
         else
           if [ "${{ matrix.toolchain }}" == "gnu" ]; then
-            ./setup.sh -t all -h -c
+            ./setup.sh -t all -h -c -o
           elif [ "${{ matrix.toolchain }}" == "llvm" ]; then
             ./setup.sh -l -h -c
           fi

--- a/.github/workflows/twister.yml
+++ b/.github/workflows/twister.yml
@@ -36,7 +36,7 @@ on:
       zephyr-ref:
         description: 'Zephyr Ref (branch, tag, SHA ...)'
         required: true
-        default: collab-sdk-dev
+        default: main
       twister-mode:
         description: 'Twister Mode'
         type: choice
@@ -284,7 +284,7 @@ jobs:
           popd
         else
           if [ "${{ github.event.inputs.sdk-toolchain }}" == "gnu" ]; then
-            ./setup.sh -t all -h -c
+            ./setup.sh -t all -h -c -o
           elif [ "${{ github.event.inputs.sdk-toolchain }}" == "llvm" ]; then
             ./setup.sh -l -h -c
           fi


### PR DESCRIPTION
This switches the CI branch from 'collab-sdk-dev' to 'main'. That requires disabling llvm testing and using `ZEPHYR_TOOLCHAIN_VARIANT=zephyr`.