### PR TITLE
ci: Disable x86-64 macOS SDK build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,8 @@ jobs:
         if [ "${build_host_all}" == "y" ]; then
           build_host_linux_x86_64="y"
           build_host_linux_aarch64="y"
-          build_host_macos_x86_64="y"
+          # NOTE: macOS x86-64 build is disabled due to various runner-related build issues.
+          # build_host_macos_x86_64="y"
           build_host_macos_aarch64="y"
           build_host_windows_x86_64="y"
         fi


### PR DESCRIPTION
There are currently various macOS runner-related issues causing build failures for the x86-64 macOS Zephyr SDK (in particular, host tools and GNU ARM toolchain).

After weeks of investigation and debugging, various issues have been identified and fixed, which include:

* `posix_spawn` failures related to a fairly low hard `kern.maxproc` limit of 2000 on some runner nodes
* unthrottled job invocation in the host tools build script causing excessive process creation
* processing overhead in older versions of Rosetta 2 emulation layer causing above-normal system resource usage

In spite of that, there are still more lingering issues (e.g. seemingly random I/O errors, runner unresponsiveness, compilation errors likely due to data corruption) which may take a considerable amount of time and developer resources to debug and fix.

Given that it has been years since Intel (x86-64) Mac devices were discontinued and the upcoming macOS 27 release plans to entirely drop x86-64 support, it would not be unreasonable to drop x86-64 macOS host support in the Zephyr SDK in order to save resources.

This is the first step in the x86-64 macOS host support phase-out, disabling the x86-64 macOS build of the Zephyr SDK in CI when triggered via push and release events -- all the existing code and underlying infrastructure to support x86-64 macOS Zephyr SDK build remain and may be invoked on-demand for now.

Unless there is a compelling reason to continue supporting the x86-64 macOS host in the Zephyr SDK, x86-64 macOS Zephyr SDK build in the main CI will remain disabled and the associated code and infrastructure may be eventually removed in the future to reduce maintenance overhead.

Note that this does not affect the AArch64 (aka. Apple Silicon) macOS support.

---

Tested in https://github.com/zephyrproject-rtos/sdk-ng/actions/runs/22123787108