### PR TITLE
gcc: add Objective-C support.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "crosstool-ng"]
 	path = crosstool-ng
-	url = https://github.com/zephyrproject-rtos/crosstool-ng.git
+	url = https://github.com/rodrigopex/crosstool-ng.git
 [submodule "binutils"]
 	path = binutils
 	url = https://github.com/zephyrproject-rtos/binutils-gdb.git

--- a/configs/common.config
+++ b/configs/common.config
@@ -17,6 +17,8 @@ CT_GCC_SRC_CUSTOM=y
 CT_GCC_CUSTOM_LOCATION="${GITHUB_WORKSPACE}/gcc"
 CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array"
 CT_CC_LANG_CXX=y
+CT_CC_LANG_OBJC=y
+CT_CC_LANG_OBJCXX=y
 
 # Newlib
 CT_NEWLIB_SRC_CUSTOM=y


### PR DESCRIPTION
Objective-C support was suppressed by the CONFIG_BARE_METAL. 

Giving it another try. First attempt: #1048 