### PR TITLE
cmake: Declare minimum backward compatible SDK version 1.0

### DIFF
--- a/cmake/Zephyr-sdkConfigVersion.cmake
+++ b/cmake/Zephyr-sdkConfigVersion.cmake
@@ -11,23 +11,17 @@ string(STRIP ${SDK_VERSION} PACKAGE_VERSION)
 if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
   set(PACKAGE_VERSION_COMPATIBLE FALSE)
 else()
-  # Currently, this Zephyr SDK is expected to work with any Zephyr project
-  # requiring this version or any older version.
-  #
-  # In case this version of Zephyr SDK is no longer backwards compatible with
-  # previous versions of Zephyr SDK, this is the place to test if the caller
-  # requested an older (incompatible) revision.
-  # For example, imagine caller requests Zephyr SDK v0.10, and this Zephyr SDK
-  # is revision v0.11, then the below snippet can be activated to ensure that
-  # this Zephyr SDK (v0.11) is marked as not compatible if caller requested an
-  # older version, like v0.10
-  # set(ZEPHYR_SDK_MINIMUM_COMPATIBLE_VERSION 0.11)
-  # if(PACKAGE_FIND_VERSION VERSION_LESS ZEPHYR_SDK_MINIMUM_COMPATIBLE_VERSION)
-  #   set(PACKAGE_VERSION_COMPATIBLE FALSE)
-  #   return()
-  # endif()
+  # SDK 1.0 is not backward compatible with older SDK releases. When Zephyr
+  # looks for an SDK version less than 1.0, this declares incompatibility to
+  # prevent older incompatible Zephyr releases from picking up SDK 1.0.
+  set(ZEPHYR_SDK_MINIMUM_COMPATIBLE_VERSION 1.0)
+  if(PACKAGE_FIND_VERSION VERSION_LESS ZEPHYR_SDK_MINIMUM_COMPATIBLE_VERSION)
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+    return()
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  endif()
 
-  set(PACKAGE_VERSION_COMPATIBLE TRUE)
   if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
     set(PACKAGE_VERSION_EXACT TRUE)
   endif()


### PR DESCRIPTION
This commit updates the ConfigVersion CMake file to declare incompatibility when Zephyr build system requests an SDK version less than 1.0 to prevent older Zephyr releases from picking up SDK 1.0.