### PR TITLE
Revert "config: Force gnu17 mode for host tools"

### DIFF
--- a/configs/common.config
+++ b/configs/common.config
@@ -1,8 +1,5 @@
 # Common crosstool-ng configurations for all toolchain variants
 
-# Use c17 instead of c23 with host tools
-CT_EXTRA_CFLAGS_FOR_HOST="-std=gnu17"
-
 # Ncurses
 CT_NCURSES_HOST_FALLBACKS="linux,xterm,xterm-color,xterm-256color,vt100,screen,screen-256color,tmux,tmux-256color"
 


### PR DESCRIPTION
This reverts commit 6d88a09291cb3fb5b81ca08379d693299b5963bb because it currently breaks macOS build.

  [ERROR]    configure: error: *** A compiler with support for C++11
  language features is required.

---

p.s. It probably has to do with Clang on macOS disabling C++ features when `-std=gnu17` is specified rather than `-std=gnu17++`. For now, I am just going to revert so as to not block the SDK 1.0 release.

p.s.2. [There are multiple upstream crosstool-ng patches supposedly fixing C23 compatibility issues](https://github.com/search?q=repo%3Acrosstool-ng%2Fcrosstool-ng+c23&type=pullrequests). Pulling these would be the proper way to fix this issue, which we would want to look into after the 1.0.0 release.