### PR TITLE
cmake: Fix OpenRISC compile target name

### DIFF
--- a/cmake/zephyr/gnu/target.cmake
+++ b/cmake/zephyr/gnu/target.cmake
@@ -11,7 +11,7 @@ set(CROSS_COMPILE_TARGET_riscv   riscv64-zephyr-elf)
 set(CROSS_COMPILE_TARGET_mips       mips-zephyr-elf)
 set(CROSS_COMPILE_TARGET_rx           rx-zephyr-elf)
 set(CROSS_COMPILE_TARGET_microblaze microblazeel-zephyr-elf)
-set(CROSS_COMPILE_TARGET_or1k       or1k-zephyr-elf)
+set(CROSS_COMPILE_TARGET_openrisc   or1k-zephyr-elf)
 set(CROSS_COMPILE_TARGET_xtensa   xtensa-${SOC_TOOLCHAIN_NAME}_zephyr-elf)
 
 # ARC uses the same source tree for both ARCv2 & ARCv3 architectures,


### PR DESCRIPTION
In the proposed Zephyr OpenRISC support pull request [1], the `ARCH` Kconfig is set to `openrisc`, effectively requiring the corresponding compile targer variable name to be `CROSS_COMPILE_TARGET_openrisc`.

In case we ever need to support a variant of OpenRISC other than `or1k` (e.g. `or2k`), a special handling may be added similar to what is done for ARCv3.

[1] https://github.com/zephyrproject-rtos/zephyr/pull/98160

---

Fixes https://github.com/zephyrproject-rtos/sdk-ng/issues/1090