### PR TITLE
ci: twister: Increase timeout to 24 hours

### DIFF
--- a/.github/workflows/twister.yml
+++ b/.github/workflows/twister.yml
@@ -139,6 +139,7 @@ jobs:
     runs-on:
       group: ${{ needs.prep.outputs.runner }}
     container: ${{ needs.prep.outputs.container }}
+    timeout-minutes: 1440
 
     defaults:
       run:


### PR DESCRIPTION
This commit increases the timeout for the build job because a Twister run with '--all' argument may take a very long time to finish.