### PR TITLE
README: drop macOS x86-64 from supported host platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following host tools are available as part of the Zephyr SDK:
 The Zephyr SDK bundle releases are available for the following host platforms:
 
 - Linux (AArch64, x86-64)
-- macOS (AArch64, x86-64)
+- macOS (AArch64)
 - Windows (x86-64)
 
 These binaries can be downloaded from


### PR DESCRIPTION
Clarify that x86-64 macOS is no longer supported.
https://github.com/zephyrproject-rtos/sdk-ng/pull/1104