### PR TITLE
xtensa: enable multilib for dc233c and sample_controller{,32}

### DIFF
--- a/configs/xtensa-dc233c_zephyr-elf.config
+++ b/configs/xtensa-dc233c_zephyr-elf.config
@@ -6,3 +6,4 @@ CT_ARCH_XTENSA=y
 CT_XTENSA_CUSTOM=y
 CT_TARGET_VENDOR="dc233c_zephyr"
 CT_TARGET_CFLAGS="-ftls-model=local-exec"
+CT_MULTILIB=y

--- a/configs/xtensa-sample_controller32_zephyr-elf.config
+++ b/configs/xtensa-sample_controller32_zephyr-elf.config
@@ -7,3 +7,4 @@ CT_XTENSA_CUSTOM=y
 CT_TARGET_VENDOR="sample_controller32_zephyr"
 CT_TARGET_CFLAGS="-ftls-model=local-exec"
 CT_CC_GCC_CONFIG_TLS=n
+CT_MULTILIB=y

--- a/configs/xtensa-sample_controller_zephyr-elf.config
+++ b/configs/xtensa-sample_controller_zephyr-elf.config
@@ -7,3 +7,4 @@ CT_XTENSA_CUSTOM=y
 CT_TARGET_VENDOR="sample_controller_zephyr"
 CT_TARGET_CFLAGS="-ftls-model=local-exec"
 CT_CC_GCC_CONFIG_TLS=n
+CT_MULTILIB=y


### PR DESCRIPTION
This enables multilib support for building GCC. This is needed to support both CALL0 and Windowed ABIs.

The corresponding GCC changes are needed to support multilib where Windowed ABI is the default.

---

GCC PR: https://github.com/zephyrproject-rtos/gcc/pull/71