### PR TITLE
ci: Link Linux gdb-py against Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1125,6 +1125,14 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y lz4 zstd
 
+        # Create and activate Python 3.12 virtual environment
+        #
+        # NOTE: This is necessary because BitBake requires Python 3.8 or above,
+        #       and the sdk-build image is based on Debian 10, which ships with
+        #       Python 3.7.
+        python3.12 -m venv venv
+        source venv/bin/activate
+
         # Check out Poky
         ${POKY_BASE}/scripts/meta-zephyr-sdk-clone.sh
 


### PR DESCRIPTION
This commit updates the CI workflow to link Linux gdb-py executables
explicitly against libpython3.12.

```
$ ldd bin/aarch64-zephyr-elf-gdb-py
        linux-vdso.so.1 (0x000078bd0acd6000)
        libncursesw.so.6 => /lib/x86_64-linux-gnu/libncursesw.so.6 (0x000078bd0ac90000)
        libtinfo.so.6 => /lib/x86_64-linux-gnu/libtinfo.so.6 (0x000078bd0ac5c000)
        libpython3.12.so.1.0 => /lib/x86_64-linux-gnu/libpython3.12.so.1.0 (0x000078bd09759000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x000078bd0ac57000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x000078bd0ac52000)
        libutil.so.1 => /lib/x86_64-linux-gnu/libutil.so.1 (0x000078bd0ac4b000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x000078bd09670000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000078bd0945e000)
        /lib64/ld-linux-x86-64.so.2 (0x000078bd0acd8000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x000078bd0ac2f000)
        libexpat.so.1 => /lib/x86_64-linux-gnu/libexpat.so.1 (0x000078bd0ac03000)
```

---

Tested in https://github.com/zephyrproject-rtos/sdk-ng/actions/runs/23381843654

Fixes https://github.com/zephyrproject-rtos/sdk-ng/issues/1100