### PR TITLE
ci: Install meson inside venv for Windows host tools build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1171,6 +1171,14 @@ jobs:
           #       ships with Python 3.7.
           python3.12 -m venv venv
           source venv/bin/activate
+
+          # Install required Python packages
+          pip install packaging
+
+          # Install meson inside virtual environment to ensure that QEMU build
+          # picks up the correct Python installation.
+          pip install meson
+          hash -r
         fi
 
         # Create output directory


### PR DESCRIPTION
Install meson inside Python 3.12 virtual environment for Windows host
tools build to ensure that the QEMU build script picks up Python 3.12
instead of the system Python 3.7 installation.

---

Tested in https://github.com/zephyrproject-rtos/sdk-ng/actions/runs/23427036886/job/68144087233