### PR TITLE
scripts: Fix macOS and Windows host tools message

### DIFF
--- a/scripts/template_setup_posix
+++ b/scripts/template_setup_posix
@@ -305,7 +305,7 @@ if [ "${do_hosttools}" = "y" ]; then
       popd
       ;;
     macos-*)
-      echo "SKIPPED: macOS host tools are not available yet."
+      # Nothing to do for macOS
       ;;
   esac
   echo

--- a/scripts/template_setup_win
+++ b/scripts/template_setup_win
@@ -218,7 +218,7 @@ if [%DO_LLVM_TOOLCHAIN%] neq [] (
 REM # Install host tools
 if [%DO_HOSTTOOLS%] neq [] (
   echo Installing host tools ...
-  echo SKIPPED: Windows host tools are not available yet.
+  REM # Nothing to do for now
   echo.
 )
 


### PR DESCRIPTION
Get rid of the "SKIPPED" message when installing the host tools on macOS and Windows because host tools for those OSes are actually available now.