### PR TITLE
README: drop NIOS II

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ The toolchains for the following target architectures are supported:
 - ARM (32-bit and 64-bit; ARMv6, ARMv7, ARMv8; A/R/M Profiles)
 - Microblaze (32-bit)
 - MIPS (32-bit and 64-bit)
-- Nios II
 - OpenRISC 1000
 - RISC-V (32-bit and 64-bit; RV32I, RV32E, RV64I)
 - RX


### PR DESCRIPTION
NIOS II support has been dropped since Zephyr SDK 1.0.0-beta1 [1]. Therefore, remove NIOS II from README.

[1] https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v1.0.0-beta1