### PR TITLE
configs: enable POSIX threading support (--enable-threads=posix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,6 +556,16 @@ jobs:
         git submodule update --depth=1 --recursive gcc_arc
         git submodule update --depth=1 --recursive picolibc
 
+    - name: Install pthread stub headers for POSIX threading support
+      run: |
+        # gthr-posix.h requires <pthread.h> in the sysroot. Install a
+        # declarations-only stub into picolibc's include directory so it
+        # gets installed to the sysroot before the final GCC build.
+        # Real implementations are provided by the target OS (e.g.
+        # Zephyr's CONFIG_POSIX_API).
+        cp ${GITHUB_WORKSPACE}/stubs/pthread.h \
+           ${GITHUB_WORKSPACE}/picolibc/newlib/libc/include/pthread.h
+
     - name: Build crosstool-ng
       run: |
         # Configure macOS build environment

--- a/configs/common.config
+++ b/configs/common.config
@@ -16,7 +16,7 @@ CT_GDB_CUSTOM_LOCATION="${GITHUB_WORKSPACE}/gdb"
 # GCC
 CT_GCC_SRC_CUSTOM=y
 CT_GCC_CUSTOM_LOCATION="${GITHUB_WORKSPACE}/gcc"
-CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array"
+CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array --enable-threads=posix"
 CT_CC_GCC_CORE_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array"
 CT_CC_LANG_CXX=y
 CT_MULTILIB_SPACE=y

--- a/stubs/pthread.h
+++ b/stubs/pthread.h
@@ -1,0 +1,97 @@
+/*
+ * Minimal pthread.h stub for bare-metal targets.
+ *
+ * Provides type definitions and function declarations needed by
+ * GCC's gthr-posix.h when the toolchain is built with
+ * --enable-threads=posix. No implementations are provided here;
+ * the target OS (e.g. Zephyr with CONFIG_POSIX_API) supplies them.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PTHREAD_H
+#define _PTHREAD_H
+
+#include <sys/types.h>
+#include <sched.h>
+#include <time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef unsigned long pthread_t;
+typedef unsigned int pthread_key_t;
+
+typedef struct { int __data; } pthread_once_t;
+typedef struct { int __data; } pthread_mutex_t;
+typedef struct { int __data; } pthread_mutexattr_t;
+typedef struct { int __data; } pthread_cond_t;
+typedef struct { int __data; } pthread_condattr_t;
+typedef struct { int __data; } pthread_rwlock_t;
+typedef struct { int __data; } pthread_rwlockattr_t;
+typedef struct { int __data; } pthread_attr_t;
+
+#define PTHREAD_ONCE_INIT { 0 }
+#define PTHREAD_MUTEX_INITIALIZER { 0 }
+#define PTHREAD_COND_INITIALIZER { 0 }
+#define PTHREAD_RWLOCK_INITIALIZER { 0 }
+#define PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP { 0 }
+
+#define PTHREAD_MUTEX_RECURSIVE 1
+
+int pthread_once(pthread_once_t *, void (*)(void));
+
+int pthread_key_create(pthread_key_t *, void (*)(void *));
+int pthread_key_delete(pthread_key_t);
+void *pthread_getspecific(pthread_key_t);
+int pthread_setspecific(pthread_key_t, const void *);
+
+int pthread_create(pthread_t *, const pthread_attr_t *,
+                   void *(*)(void *), void *);
+int pthread_join(pthread_t, void **);
+int pthread_detach(pthread_t);
+int pthread_cancel(pthread_t);
+int pthread_equal(pthread_t, pthread_t);
+pthread_t pthread_self(void);
+
+int pthread_mutex_init(pthread_mutex_t *, const pthread_mutexattr_t *);
+int pthread_mutex_destroy(pthread_mutex_t *);
+int pthread_mutex_lock(pthread_mutex_t *);
+int pthread_mutex_trylock(pthread_mutex_t *);
+int pthread_mutex_timedlock(pthread_mutex_t *,
+                            const struct timespec *);
+int pthread_mutex_unlock(pthread_mutex_t *);
+
+int pthread_mutexattr_init(pthread_mutexattr_t *);
+int pthread_mutexattr_destroy(pthread_mutexattr_t *);
+int pthread_mutexattr_settype(pthread_mutexattr_t *, int);
+
+int pthread_cond_init(pthread_cond_t *, const pthread_condattr_t *);
+int pthread_cond_destroy(pthread_cond_t *);
+int pthread_cond_wait(pthread_cond_t *, pthread_mutex_t *);
+int pthread_cond_timedwait(pthread_cond_t *, pthread_mutex_t *,
+                           const struct timespec *);
+int pthread_cond_signal(pthread_cond_t *);
+int pthread_cond_broadcast(pthread_cond_t *);
+
+int pthread_rwlock_rdlock(pthread_rwlock_t *);
+int pthread_rwlock_tryrdlock(pthread_rwlock_t *);
+int pthread_rwlock_wrlock(pthread_rwlock_t *);
+int pthread_rwlock_trywrlock(pthread_rwlock_t *);
+int pthread_rwlock_unlock(pthread_rwlock_t *);
+
+int pthread_attr_init(pthread_attr_t *);
+int pthread_attr_destroy(pthread_attr_t *);
+int pthread_attr_setdetachstate(pthread_attr_t *, int);
+
+int pthread_getschedparam(pthread_t, int *, struct sched_param *);
+int pthread_setschedparam(pthread_t, int, const struct sched_param *);
+
+int sched_yield(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _PTHREAD_H */


### PR DESCRIPTION
## Summary

Enable C++ threading primitives (`std::mutex`, `std::thread`,
`std::condition_variable`) by building GCC with `--enable-threads=posix`
instead of the default `--enable-threads=no` for bare-metal targets.

This defines `_GLIBCXX_HAS_GTHREADS` in libstdc++ and uses `gthr-posix.h`
as the default threading backend.

### The problem

The Zephyr SDK is built with `--enable-threads=no`, which makes
`std::mutex`, `std::thread`, and `std::condition_variable` unavailable.
Any C++ code using STL threading primitives fails to compile. This blocks
porting C++ libraries that depend on standard threading (ExecuTorch,
XNNPACK, folly, and any Android/Linux C++ code targeting Zephyr).

### Previous attempts

- PR #735: Added `--enable-threads=c11`, merged Oct 2023
- PR #753: Reverted PR #735 (May 2024) — C11 threads caused link failures
  for apps without POSIX threading enabled
- PR #774: Second attempt with weak stubs, never merged

### This approach

Two changes:

1. **`configs/common.config`**: Add `--enable-threads=posix` to
   `CT_CC_GCC_EXTRA_CONFIG_ARRAY`

2. **`stubs/pthread.h`**: A declarations-only stub header installed into
   picolibc's include directory during the build. It provides the type
   definitions and function declarations that `gthr-posix.h` requires
   (`pthread_mutex_t`, `pthread_cond_t`, `pthread_t`, etc.) but **no
   implementations**. The target OS supplies real functions at link time.

This avoids the link failures from previous attempts because:
- The stub contains only declarations, not code
- No pthread symbols are compiled into libgcc or libstdc++
- Applications using threading need `CONFIG_POSIX_API=y` (or equivalent
  weak stubs) to supply the actual pthread implementations

### Impact

- `std::mutex`, `std::thread`, `std::condition_variable` compile and link
- Applications using threading need `CONFIG_POSIX_API=y` or weak pthread
  stubs providing the declared symbols
- No behavior change for code not using C++ threading
- No additional link-time dependencies for non-threading code

### Companion change (Zephyr)

For targets without `CONFIG_POSIX_API`, weak pthread stubs should be added
to Zephyr's `lib/cpp/` to satisfy the linker. These stubs return `ENOSYS`
for operations requiring real threading and are overridden when
`CONFIG_POSIX_API=y`. This will be submitted as a separate PR to the Zephyr
main repository.

## Test plan

- [x] `aarch64-zephyr-elf` toolchain build passes (45m48s on GitHub Actions)
- [x] `arm-zephyr-eabi` toolchain build passes
- [x] `_GLIBCXX_HAS_GTHREADS` is defined as `1` in the built toolchain
- [x] `pthread.h` is installed in the sysroot
- [x] `gthr-default.h` resolves to `gthr-posix.h`
- [x] `std::mutex` / `std::condition_variable` / `std::thread` compile
- [x] `std::condition_variable` out-of-line symbols present in `libstdc++.a`
- [x] Full link succeeds with weak pthread stubs
- [x] **Backward compat**: Plain C compiles (no impact)
- [x] **Backward compat**: C++ without threading compiles (no impact)
- [x] **Backward compat**: No pthread symbols in non-threading object files
- [x] **Backward compat**: `std::atomic` works without pulling in pthread
- [x] **Backward compat**: Including `<mutex>` header without using it: compiles, 0 pthread refs
- [x] **Backward compat**: Using `std::mutex`: compiles, 5 pthread refs (expected)