### PR TITLE
gcc: add rv64-imafc multilib support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/zephyrproject-rtos/binutils-gdb.git
 [submodule "gcc"]
 	path = gcc
-	url = https://github.com/zephyrproject-rtos/gcc.git
+	url = https://github.com/quic-lingutla/gcc.git
 [submodule "gdb"]
 	path = gdb
 	url = https://github.com/zephyrproject-rtos/binutils-gdb.git


### PR DESCRIPTION
Add multilib support for rv64-imafc ISA to enable systems with single precision floating points.