### PR TITLE
Scripts/llvm: Use local-exec tls model

### DIFF
--- a/scripts/llvm/CMakeLists.txt
+++ b/scripts/llvm/CMakeLists.txt
@@ -944,7 +944,7 @@ macro(
 endmacro()
 
 function(get_runtimes_flags directory flags)
-    set(runtimes_flags "${flags} -ffunction-sections -fdata-sections -fno-ident --sysroot ${LLVM_BINARY_DIR}/${directory}" PARENT_SCOPE)
+    set(runtimes_flags "${flags} -ffunction-sections -fdata-sections -fno-ident -ftls-model=local-exec --sysroot ${LLVM_BINARY_DIR}/${directory}" PARENT_SCOPE)
 endfunction()
 
 function(


### PR DESCRIPTION
LLVM C++ runtime libraries are build with TLS-model initial-exec by default Use local-exec instead like the other libraries to avoid mismatching these

Fixes: https://github.com/zephyrproject-rtos/sdk-ng/issues/1159